### PR TITLE
[APH-942] getPaywalls(), purchase() [APH-943] paywallShown(), paywallClosed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,23 @@
     - method paywallClosed(ApphudPaywall paywall) [iOS]
     
 - Bugs were fixed:
-    - Method getPaywalls() always returns result with error [Android]
+    - Method restorePurchases() always returns result with error [Android] 
 
 - Dependencies of Native SDK's were updated to:
-    - [Android] 1.1.0
+    - [Android] 1.1.3
     - [iOS] 2.1.1
       
 - **BREAKING** refactor [iOS], [Android]:
     - AppHud class was renamed to Apphud
     - ApphudProduct was renamed to ApphudProductComposite and was marked as deprecated
     - Method purchase(String productId) -> purchase({String? productId}). Parameter productId was marked as deprecated
-   
+
+- Methods are deprecated:
+    - didFetchProductsNotification()
+    - refreshStoreKitProducts()
+    - product()
+    - products()
+     
 ## 2.0.5
 - [iOS] Add method collectSearchAdsAttribution() to send search ads attribution data to Apphud.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.github.apphud:ApphudSDK-Android:1.1.0"
+    implementation "com.github.apphud:ApphudSDK-Android:1.1.1"
     implementation 'com.android.billingclient:billing:3.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.github.apphud:ApphudSDK-Android:1.1.1"
+    implementation "com.github.apphud:ApphudSDK-Android:1.1.3"
     implementation 'com.android.billingclient:billing:3.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/android/src/main/kotlin/com/apphud/fluttersdk/Extensions.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/Extensions.kt
@@ -19,10 +19,10 @@ fun ApphudPaywall.toMap(): HashMap<String, Any?> {
 
 fun ApphudProduct.toMap(): HashMap<String, Any?> {
     return hashMapOf(
-            "productId" to productId,
+            "productId" to product_id,
             "name" to name,
             "store" to store,
-            "paywallId" to paywallId,
+            "paywallId" to paywall_id,
             "skuDetails" to skuDetails?.toMap()
     )
 }

--- a/android/src/main/kotlin/com/apphud/fluttersdk/handlers/MakePurchaseHandler.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/handlers/MakePurchaseHandler.kt
@@ -179,10 +179,10 @@ class MakePurchaseHandler(override val routes: List<String>, val activity: Activ
 
                 val product = ApphudProduct(
                         id = id,
-                        productId = productId,
+                        product_id = productId,
                         name = name,
                         store = store,
-                        paywallId = paywallId,
+                        paywall_id = paywallId,
                         skuDetails = null
                 )
 


### PR DESCRIPTION
## 2.0.6 
- Paywalls features were implemented:
    - method getPaywalls() [iOS], [Android]
    - method permissionGroups() [iOS], [Android]
    - method purchase({ ApphudProduct? product }) [iOS], [Android]
    - method paywallShown(ApphudPaywall paywall) [iOS]  
    - method paywallClosed(ApphudPaywall paywall) [iOS]
    
- Bugs were fixed:
    - Method restorePurchases() always returns result with error [Android] 

- Dependencies of Native SDK's were updated to:
    - [Android] 1.1.3
    - [iOS] 2.1.1
      
- **BREAKING** refactor [iOS], [Android]:
    - AppHud class was renamed to Apphud
    - ApphudProduct was renamed to ApphudProductComposite and was marked as deprecated
    - Method purchase(String productId) -> purchase({String? productId}). Parameter productId was marked as deprecated

- Methods are deprecated:
    - didFetchProductsNotification()
    - refreshStoreKitProducts()
    - product()
    - products()