### PR TITLE
2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.2.1
+- [Android] Fixed bug that method hasActiveSubscription was false for paying users at launch before data refreshes. Now value is cached.
+- [Android] Fixed internal potential crash
+
+- Dependencies of Native SDK's were updated to:
+  - [Android] 1.5.5
+  - [iOS] 
+
+
 ## 2.2.0
 - [iOS] The optional parameter 'level' was added to the method enableDebugLogs(). 
     Possible values are:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## 2.2.1
 - [Android] Fixed bug that method hasActiveSubscription was false for paying users at launch before data refreshes. Now value is cached.
 - [Android] Fixed internal potential crash
+- [iOS] Fixed 403 server error bug, when user could be blocked from sever 403 error code
+- [iOS] Add push token cache
+- [iOS] Update general cache time
+- [iOS] Update some Logs
+
 
 - Dependencies of Native SDK's were updated to:
   - [Android] 1.5.5
-  - [iOS] 
+  - [iOS] 2.5.7
 
 
 ## 2.2.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -82,7 +82,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "com.apphud:ApphudSDK-Android:1.5.3"
+    implementation "com.apphud:ApphudSDK-Android:1.5.5"
     implementation 'com.android.billingclient:billing:4.0.0'
     implementation 'com.google.code.gson:gson:2.8.8'
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.0"
+    version: "2.2.1"
   args:
     dependency: transitive
     description:

--- a/ios/Classes/handlers/PaywallLogs/PaywallClosed.swift
+++ b/ios/Classes/handlers/PaywallLogs/PaywallClosed.swift
@@ -13,8 +13,9 @@ final class PaywallClosedRequest: Request {
 
     func startRequest(arguments: PaywallArgumentParser.ArgumentType, result: @escaping FlutterResult) {
         Apphud.getPaywalls { (paywalls:[ApphudPaywall]?, _ ) in
-            let paywall = paywalls?.first { pw in return pw.identifier==arguments }
-            Apphud.paywallClosed(paywall)
+            if let paywall = paywalls?.first(where: { pw in return pw.identifier==arguments }) {
+                Apphud.paywallClosed(paywall)
+            }
         }
         result(nil)
     }

--- a/ios/Classes/handlers/PaywallLogs/PaywallShown.swift
+++ b/ios/Classes/handlers/PaywallLogs/PaywallShown.swift
@@ -13,8 +13,9 @@ final class PaywallShownRequest: Request {
 
     func startRequest(arguments: PaywallArgumentParser.ArgumentType, result: @escaping FlutterResult) {
         Apphud.getPaywalls { (paywalls:[ApphudPaywall]?, _ ) in
-            let paywall = paywalls?.first { pw in return pw.identifier==arguments }
-            Apphud.paywallShown(paywall)
+            if let paywall = paywalls?.first(where: { pw in return pw.identifier==arguments }) {
+                Apphud.paywallShown(paywall)
+            }
         }
         result(nil)
     }

--- a/ios/apphud.podspec
+++ b/ios/apphud.podspec
@@ -24,7 +24,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ApphudSDK','2.5.6'
+  s.dependency 'ApphudSDK','2.5.7'
   s.platform = :ios, '11.2'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/apphud.dart
+++ b/lib/apphud.dart
@@ -261,11 +261,12 @@ class Apphud {
     await _channel.invokeMethod('presentOfferCodeRedemptionSheet');
   }
 
-  /// iOS only. Returns paywalls with their `SKProducts`, if configured in Apphud Products Hub.
-  ///
-  /// Returns `null` if StoreKit products are not yet fetched from the App Store.
-  /// To get notified when paywalls are ready to use, use `paywallsDidFullyLoad`
-  /// of `ApphudListener` – when it's called, paywalls are populated with their `SKProducts`.
+  /// Returns paywalls configured in Apphud Dashboard > Product Hub > Paywalls.
+  /// Each paywall contains an array of `ApphudProduct` objects that you use for purchase.
+  /// `ApphudProduct` is Apphud's wrapper around `SkuDetails` or 'SkProduct'.
+  /// Returns empty array if paywalls are not yet fetched.
+  /// To get notified when paywalls are ready to use, use ApphudListener's  `paywallsDidLoad` or `paywallsDidFullyLoad` methods.
+  /// Best practice is to use this method together with `paywallsDidFullyLoad` listener.
   static Future<ApphudPaywalls?> paywalls() async {
     final Map<dynamic, dynamic>? json =
         await _channel.invokeMethod<Map<dynamic, dynamic>>('paywalls');
@@ -274,9 +275,11 @@ class Apphud {
 
 // Handle Purchases
 
-  /// Fetches permission groups configured in Apphud dashboard.
+  /// Returns permission groups configured in Apphud dashboard > Product Hub > Products. Groups are cached on device.
   ///
-  /// Groups are cached on device.
+  /// Note that this method returns empty array if `SkuDetails` or 'SkProduct' are not yet fetched from Google Play / App Store.
+  /// To get notified when `permissionGroups` are ready to use, use ApphudListener's `paywallsDidFullyLoad` method
+  /// Best practice is not to use this method at all, but use `paywalls()` instead.
   static Future<List<ApphudGroup>> permissionGroups() async {
     List<Map<dynamic, dynamic>> groups =
         (await _channel.invokeMethod<List<dynamic>>('permissionGroups'))!
@@ -284,9 +287,9 @@ class Apphud {
     return groups.map((json) => ApphudGroup.fromJson(json)).toList();
   }
 
-  /// Returns true if user has active subscription.
-  ///
-  /// Use this method to determine whether or not to unlock premium functionality to the user.
+  /// Returns `true` if user has active subscription. Value is cached on device.
+  /// Use this method to determine whether or not user has active premium subscription.
+  /// Note that if you have lifetime purchases, you must use another `isNonRenewingPurchaseActive` method.
   static Future<bool> hasActiveSubscription() async {
     return (await _channel.invokeMethod('hasActiveSubscription')) ?? false;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apphud
 description: Official Apphud Flutter SDK is a lightweight open-source library to manage auto-renewable subscriptions and other in-app purchases in your iOS/Android app. No backend required.
-version: 2.2.0
+version: 2.2.1
 homepage: 'https://apphud.com'
 repository: 'https://github.com/apphud/ApphudSDK-Flutter'
 


### PR DESCRIPTION
- [Android] Fixed bug that method hasActiveSubscription was false for paying users at launch before data refreshes. Now value is cached.
- [Android] Fixed internal potential crash
- [iOS] Fixed 403 server error bug, when user could be blocked from sever 403 error code
- [iOS] Add push token cache
- [iOS] Update general cache time
- [iOS] Update some Logs


- Dependencies of Native SDK's were updated to:
  - [Android] 1.5.5
  - [iOS] 2.5.7