### PR TITLE
2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.6
+- [iOS] Bug fix for Flutter SDK
+- Dependencies of Native SDK's were updated to:
+  - [iOS] 2.8.8
+
 ## 2.2.5
 - [iOS], [Android] `ApphudListener`'s method `userDidLoad` is introduced.
 - [iOS], [Android] **BREAKING** Method `paywallsDidLoad` of `ApphudListener` is removed. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Dependencies of Native SDK's were updated to:
   - [Android] 1.6.2
-  - [iOS] 2.8.5
+  - [iOS] 2.8.6
 
 ## 2.2.3
 - [iOS] Payment swizzle was disabled for observer mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.2.5
+- [iOS], [Android] `ApphudListener`'s method `userDidLoad` is introduced.
+- [iOS], [Android] **BREAKING** Method `paywallsDidLoad` of `ApphudListener` is removed. 
+  Please use `ApphudListener`'s methods `userDidLoad` or `paywallsDidFullyLoad` methods,
+  depending on whether or not you need `SkuDetails`/`SKProducts` to be already filled in paywalls.
+- [Android] Internal improvements and bug fixing.
+  
+- Dependencies of Native SDK's were updated to:
+  - [Android] 1.6.4
+  - [iOS] 2.8.5
+
 ## 2.2.4
 - [Android] Fixed a bug when ApphudListener’s paywallsDidFullyLoad method wasn’t called in some cases.
 - [Android] Added new method refreshEntitlements().

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Greetings!
 
-Apphud SDK is an open-source Swift library to manage auto-renewable subscriptions and other in-app purchases in your app.
+Apphud SDK is an open-source library to manage auto-renewable subscriptions and other in-app purchases in your app.
 <p align="center">
 <img src="https://apphud.com/images/greetings.png" width="30%" height="30%" />
 </p>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -82,7 +82,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "com.apphud:ApphudSDK-Android:1.6.2"
+    implementation "com.apphud:ApphudSDK-Android:1.6.4"
     implementation 'com.android.billingclient:billing:4.0.0'
     implementation 'com.google.code.gson:gson:2.8.8'
 }

--- a/android/src/main/kotlin/com/apphud/fluttersdk/handlers/ApphudListenerHandler.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/handlers/ApphudListenerHandler.kt
@@ -62,11 +62,11 @@ class ApphudListenerHandler(private val channel: MethodChannel) : MethodChannel.
         }
     }
 
-    override fun paywallsDidLoad(paywalls: List<ApphudPaywall>) {
+    override fun userDidLoad() {
         if (isListeningStarted) {
             val resultMap = hashMapOf<String, Any?>()
-            resultMap["paywalls"] = paywalls.map { paywall -> paywall.toMap() }
-            channel.invokeMethod("paywallsDidLoad", resultMap)
+            resultMap["paywalls"] = Apphud.paywalls().map { paywall -> paywall.toMap() }
+            channel.invokeMethod("userDidLoad", resultMap)
         }
     }
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -4,8 +4,6 @@
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
-pod 'ApphudSDK', :git => 'https://github.com/apphud/ApphudSDK.git'
-
 project 'Runner', {
   'Debug' => :debug,
   'Profile' => :release,

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -4,6 +4,8 @@
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
+pod 'ApphudSDK', :git => 'https://github.com/apphud/ApphudSDK.git'
+
 project 'Runner', {
   'Debug' => :debug,
   'Profile' => :release,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,27 +7,23 @@ PODS:
 
 DEPENDENCIES:
   - apphud (from `.symlinks/plugins/apphud/ios`)
-  - ApphudSDK (from `https://github.com/apphud/ApphudSDK.git`)
   - Flutter (from `Flutter`)
+
+SPEC REPOS:
+  trunk:
+    - ApphudSDK
 
 EXTERNAL SOURCES:
   apphud:
     :path: ".symlinks/plugins/apphud/ios"
-  ApphudSDK:
-    :git: https://github.com/apphud/ApphudSDK.git
   Flutter:
     :path: Flutter
-
-CHECKOUT OPTIONS:
-  ApphudSDK:
-    :commit: 3d299069829053f3fb0d93a693107bd688aec1fa
-    :git: https://github.com/apphud/ApphudSDK.git
 
 SPEC CHECKSUMS:
   apphud: c52541b13b70aa7f4657edca19dd28e6cffba6d7
   ApphudSDK: 244d8554b544459d897ce47f6738d69ffb71792e
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
 
-PODFILE CHECKSUM: 4e191ead8a5259cd4c3958f5a3440518f7a3a872
+PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 
 COCOAPODS: 1.11.3

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,29 +1,33 @@
 PODS:
-  - apphud (2.2.4):
-    - ApphudSDK (= 2.8.5)
+  - apphud (2.2.5):
+    - ApphudSDK (= 2.8.6)
     - Flutter
-  - ApphudSDK (2.8.5)
+  - ApphudSDK (2.8.6)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
   - apphud (from `.symlinks/plugins/apphud/ios`)
+  - ApphudSDK (from `https://github.com/apphud/ApphudSDK.git`)
   - Flutter (from `Flutter`)
-
-SPEC REPOS:
-  trunk:
-    - ApphudSDK
 
 EXTERNAL SOURCES:
   apphud:
     :path: ".symlinks/plugins/apphud/ios"
+  ApphudSDK:
+    :git: https://github.com/apphud/ApphudSDK.git
   Flutter:
     :path: Flutter
 
+CHECKOUT OPTIONS:
+  ApphudSDK:
+    :commit: 3d299069829053f3fb0d93a693107bd688aec1fa
+    :git: https://github.com/apphud/ApphudSDK.git
+
 SPEC CHECKSUMS:
-  apphud: 093ca538dc6493af44836fbe0deb7bf025269ded
-  ApphudSDK: af0f66b67136074e094f3ceec45c0a3dabe223df
+  apphud: c52541b13b70aa7f4657edca19dd28e6cffba6d7
+  ApphudSDK: 244d8554b544459d897ce47f6738d69ffb71792e
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
 
-PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+PODFILE CHECKSUM: 4e191ead8a5259cd4c3958f5a3440518f7a3a872
 
 COCOAPODS: 1.11.3

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - apphud (2.2.5):
-    - ApphudSDK (= 2.8.6)
+  - apphud (2.2.6):
+    - ApphudSDK (= 2.8.8)
     - Flutter
-  - ApphudSDK (2.8.6)
+  - ApphudSDK (2.8.8)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  apphud: c52541b13b70aa7f4657edca19dd28e6cffba6d7
-  ApphudSDK: 244d8554b544459d897ce47f6738d69ffb71792e
+  apphud: bc577fdac0b3a2b46423fa281c7b8428df5aa644
+  ApphudSDK: ef62166ff111404f1fa01a4cd4552d266b778565
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c

--- a/example/lib/src/feature/initialization/initialization_bloc.dart
+++ b/example/lib/src/feature/initialization/initialization_bloc.dart
@@ -104,8 +104,8 @@ class InitializationBloc extends Bloc<InitializationEvent, InitializationState>
   }
 
   @override
-  Future<void> paywallsDidLoad(ApphudPaywalls paywalls) async {
-    printAsJson('ApphudListener.paywallsDidLoad', paywalls);
+  Future<void> userDidLoad(ApphudPaywalls paywalls) async {
+    printAsJson('ApphudListener.userDidLoad', paywalls);
   }
 
   @override

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.4"
+    version: "2.2.5"
   args:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.5"
+    version: "2.2.6"
   args:
     dependency: transitive
     description:

--- a/ios/Classes/handlers/ApphudDelegate/ApphudDelegateHandler.swift
+++ b/ios/Classes/handlers/ApphudDelegate/ApphudDelegateHandler.swift
@@ -37,13 +37,12 @@ public class ApphudDelegateHandler: NSObject, FlutterPlugin, ApphudDelegate {
     private func start() {
         isListeningStarted = true
         Apphud.setDelegate(self)
-        Apphud.paywallsDidLoadCallback(self.paywallsDidLoadCallback)
     }
     private func stop() {
         isListeningStarted = false
     }
     
-    private func paywallsDidLoadCallback(paywalls:[ApphudPaywall]) {
+    public func paywallsDidFullyLoad(paywalls:[ApphudPaywall]) {
         if(isListeningStarted){
             channel.invokeMethod("paywallsDidFullyLoad",
                                  arguments: [
@@ -76,6 +75,15 @@ public class ApphudDelegateHandler: NSObject, FlutterPlugin, ApphudDelegate {
     public func apphudDidChangeUserID(_ userID: String) {
         if(isListeningStarted) {
             channel.invokeMethod("didChangeUserID", arguments:userID)
+        }
+    }
+    
+    public func userDidLoad(rawPaywalls:[ApphudPaywall]) {
+        if(isListeningStarted){
+            channel.invokeMethod("userDidLoad",
+                                 arguments: [
+                                            "paywalls" : rawPaywalls.map({ (paywall: ApphudPaywall) in paywall.toMap() }),
+                                            ])
         }
     }
 }

--- a/ios/apphud.podspec
+++ b/ios/apphud.podspec
@@ -24,7 +24,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ApphudSDK','2.8.5'
+  s.dependency 'ApphudSDK','2.8.6'
   s.platform = :ios, '11.2'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/apphud.podspec
+++ b/ios/apphud.podspec
@@ -24,7 +24,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ApphudSDK','2.8.6'
+  s.dependency 'ApphudSDK','2.8.8'
   s.platform = :ios, '11.2'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/apphud.dart
+++ b/lib/apphud.dart
@@ -66,6 +66,8 @@ class Apphud {
 
   /// Updates user ID value.
   ///
+  /// Note that it should be called only after user is registered, i.e.
+  /// inside ApphudListener's userDidRegister method.
   /// - parameter [userID] is required. New user ID value.
   static Future<void> updateUserID(String userID) =>
       _channel.invokeMethod('updateUserID', {'userID': userID});
@@ -266,7 +268,7 @@ class Apphud {
   /// Each paywall contains an array of `ApphudProduct` objects that you use for purchase.
   /// `ApphudProduct` is Apphud's wrapper around `SkuDetails` or 'SkProduct'.
   /// Returns empty array if paywalls are not yet fetched.
-  /// To get notified when paywalls are ready to use, use ApphudListener's  `paywallsDidLoad` or `paywallsDidFullyLoad` methods.
+  /// To get notified when paywalls are ready to use, use ApphudListener's  `userDidLoad` or `paywallsDidFullyLoad` methods.
   /// Best practice is to use this method together with `paywallsDidFullyLoad` listener.
   static Future<ApphudPaywalls?> paywalls() async {
     final Map<dynamic, dynamic>? json =

--- a/lib/listener/apphud_listener.dart
+++ b/lib/listener/apphud_listener.dart
@@ -14,8 +14,13 @@ abstract class ApphudListener {
   /// Called when paywalls are fully loaded with their SkuDetails or SkProducts
   Future<void> paywallsDidFullyLoad(ApphudPaywalls paywalls);
 
-  /// Android only. Called when paywalls are loaded, however SkuDetails may still be nil at the moment
-  Future<void> paywallsDidLoad(ApphudPaywalls paywalls);
+  /// Called when user is registered in Apphud [or used from cache].
+  ///
+  /// This method is called once per app lifecycle.
+  /// The `paywalls` array may not yet have `SKProducts`/'SkuDetails', so this method should not be used for paywalls management.
+  /// However, if using A/B Testing, `paywalls` can be used to fetch `experimentName`, `variationName` or other parameters
+  /// like `json` from your experimental paywall.
+  Future<void> userDidLoad(ApphudPaywalls paywalls);
 
   /// Returns array of subscriptions that user ever purchased. Empty array means user never purchased a subscription.
   ///

--- a/lib/listener/apphud_listener_handler.dart
+++ b/lib/listener/apphud_listener_handler.dart
@@ -35,8 +35,8 @@ class ApphudListenerHandler {
         unawaited(_handlePaywallsDidFullyLoad(call.arguments));
         break;
 
-      case 'paywallsDidLoad':
-        unawaited(_handlePaywallsDidLoad(call.arguments));
+      case 'userDidLoad':
+        unawaited(_handleUserDidLoad(call.arguments));
         break;
 
       case 'apphudSubscriptionsUpdated':
@@ -68,9 +68,9 @@ class ApphudListenerHandler {
     unawaited(_listener.paywallsDidFullyLoad(ApphudPaywalls.fromJson(map)));
   }
 
-  Future<void> _handlePaywallsDidLoad(dynamic arguments) async {
+  Future<void> _handleUserDidLoad(dynamic arguments) async {
     final Map<dynamic, dynamic> map = arguments;
-    unawaited(_listener.paywallsDidLoad(ApphudPaywalls.fromJson(map)));
+    unawaited(_listener.userDidLoad(ApphudPaywalls.fromJson(map)));
   }
 
   Future<void> _handleApphudSubscriptionsUpdated(dynamic arguments) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,7 +140,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   file:
     dependency: transitive
     description:
@@ -276,7 +276,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -304,7 +304,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pedantic:
     dependency: "direct dev"
     description:
@@ -372,7 +372,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -414,7 +414,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:
@@ -435,7 +435,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   watcher:
     dependency: transitive
     description:
@@ -458,5 +458,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apphud
 description: Official Apphud Flutter SDK is a lightweight open-source library to manage auto-renewable subscriptions and other in-app purchases in your iOS/Android app. No backend required.
-version: 2.2.5
+version: 2.2.6
 homepage: 'https://apphud.com'
 repository: 'https://github.com/apphud/ApphudSDK-Flutter'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apphud
 description: Official Apphud Flutter SDK is a lightweight open-source library to manage auto-renewable subscriptions and other in-app purchases in your iOS/Android app. No backend required.
-version: 2.2.4
+version: 2.2.5
 homepage: 'https://apphud.com'
 repository: 'https://github.com/apphud/ApphudSDK-Flutter'
 


### PR DESCRIPTION
- [iOS], [Android] `ApphudListener`'s method `userDidLoad` is introduced.
- [iOS], [Android] **BREAKING** Method `paywallsDidLoad` of `ApphudListener` is removed. 
  Please use `ApphudListener`'s methods `userDidLoad` or `paywallsDidFullyLoad` methods,
  depending on whether or not you need `SkuDetails`/`SKProducts` to be already filled in paywalls.
- [Android] Internal improvements and bug fixing.