### PR TITLE
Move ApphudListenerHandler init to onAttachedToActivity

### DIFF
--- a/android/src/main/kotlin/com/apphud/fluttersdk/ApphudPlugin.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/ApphudPlugin.kt
@@ -33,9 +33,7 @@ class ApphudPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     override
     fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "apphud")
-        channel.setMethodCallHandler(this)
         listenerChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "apphud/listener")
-        listenerHandler = ApphudListenerHandler(listenerChannel)
         this.context = flutterPluginBinding.applicationContext
     }
 
@@ -51,12 +49,13 @@ class ApphudPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-        channel.setMethodCallHandler(null)
-        listenerHandler.dispose()
-        listenerHandler
+
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        channel.setMethodCallHandler(this)
+        listenerHandler = ApphudListenerHandler(listenerChannel)
+
         activity = binding.activity
 
         val sActivity = activity ?: return
@@ -82,13 +81,22 @@ class ApphudPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     override fun onDetachedFromActivityForConfigChanges() {
         activity = null
+
+        channel.setMethodCallHandler(null)
+        listenerHandler.dispose()
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         activity = binding.activity
+
+        channel.setMethodCallHandler(this)
+        listenerHandler = ApphudListenerHandler(listenerChannel)
     }
 
     override fun onDetachedFromActivity() {
         activity = null
+
+        channel.setMethodCallHandler(null)
+        listenerHandler.dispose()
     }
 }

--- a/android/src/main/kotlin/com/apphud/fluttersdk/handlers/ApphudListenerHandler.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/handlers/ApphudListenerHandler.kt
@@ -21,8 +21,14 @@ class ApphudListenerHandler(private val channel: MethodChannel) : MethodChannel.
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
-            "startListening" -> start()
-            "stopListening" -> stop()
+            "startListening" -> {
+                start()
+                result.success(null)
+            }
+            "stopListening" -> {
+                stop()
+                result.success(null)
+            }
         }
     }
 


### PR DESCRIPTION
this PR added fix/workaround for this issue - https://github.com/apphud/ApphudSDK-Flutter/issues/38

With similiar problem square faced up [there](https://github.com/square/in-app-payments-flutter-plugin/issues/150)