### PR TITLE
2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.4.4
+
+- [Android] **BREAKING** `Future<List<ApphudPlacement>> placementsDidLoadCallback()` renamed to `Future<ApphudPlacements> fetchPlacements()`
+- [Android] `paywallsDidLoadCallback` call result contains optional `ApphudError`
+- [Android] `refreshUserData` method was introduced
+- [Android] `ApphudError` now contains `networkIssue`, `billingResponseCode` and `billingErrorTitle` attributes 
+- [iOS], [Android] `ApphudPaywall` now contains `variationName` and `parentPaywallIdentifier` attributes
+
+- Dependencies of Native SDK's were updated to:
+  - [Android] 2.4.2
+   
 ## 2.4.3
 - [Android] fixed some build issues
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "com.apphud:ApphudSDK-Android:2.3.9"
+    implementation "com.apphud:ApphudSDK-Android:2.4.2"
     implementation 'com.android.billingclient:billing:6.1.0'
     implementation 'com.google.code.gson:gson:2.8.8'
 }

--- a/android/src/main/kotlin/com/apphud/fluttersdk/ApphudPlugin.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/ApphudPlugin.kt
@@ -128,7 +128,7 @@ class ApphudPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private fun setHeaders() {
         HeadersInterceptor.X_SDK = "Flutter"
-        HeadersInterceptor.X_SDK_VERSION = "2.4.3"
+        HeadersInterceptor.X_SDK_VERSION = "2.4.4"
     }
 
     override fun onDetachedFromActivityForConfigChanges() {

--- a/android/src/main/kotlin/com/apphud/fluttersdk/Extensions.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/Extensions.kt
@@ -13,7 +13,9 @@ fun ApphudPaywall.toMap(): HashMap<String, Any?> {
         "experimentName" to experimentName,
         "json" to json,
         "products" to products?.map { it.toMap() },
-        "placementIdentifier" to placementIdentifier
+        "placementIdentifier" to placementIdentifier,
+        "variationName" to variationName,
+        "parentPaywallIdentifier" to parentPaywallIdentifier,
     )
 }
 
@@ -73,7 +75,10 @@ fun ProductDetails.PricingPhase.toMap(): HashMap<String, Any?> {
 fun ApphudError.toMap(): HashMap<String, Any?> {
     return hashMapOf(
         "message" to message,
-        "errorCode" to errorCode
+        "errorCode" to errorCode,
+        "networkIssue" to networkIssue(),
+        "billingResponseCode" to billingResponseCode(),
+        "billingErrorTitle" to billingErrorTitle(),
     )
 }
 

--- a/android/src/main/kotlin/com/apphud/fluttersdk/handlers/MakePurchaseHandler.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/handlers/MakePurchaseHandler.kt
@@ -6,6 +6,7 @@ import com.apphud.fluttersdk.FlutterSdkCommon
 import com.apphud.fluttersdk.toApphudProduct
 import com.apphud.fluttersdk.toMap
 import com.apphud.sdk.Apphud
+import com.apphud.sdk.ApphudError
 import com.apphud.sdk.ApphudPurchaseResult
 import com.apphud.sdk.domain.ApphudPaywall
 import com.apphud.sdk.domain.ApphudProduct
@@ -68,6 +69,8 @@ class MakePurchaseHandler(
             MakePurchaseRoutes.permissionGroups.name -> getPermissionGroups(result)
 
             MakePurchaseRoutes.rawPaywalls.name -> rawPaywalls(result)
+
+            MakePurchaseRoutes.refreshUserData.name -> refreshUserData(result)
         }
     }
 
@@ -93,9 +96,10 @@ class MakePurchaseHandler(
     }
 
     private fun paywallsDidLoadCallback(result: MethodChannel.Result) {
-        Apphud.paywallsDidLoadCallback { paywalls ->
+        Apphud.paywallsDidLoadCallback { paywalls, error ->
             val resultMap = hashMapOf<String, Any?>()
             resultMap["paywalls"] = paywalls.map { paywall -> paywall.toMap() }
+            resultMap["error"] = error?.toMap()
             handleOnMainThread { result.success(resultMap) }
         }
     }
@@ -207,6 +211,11 @@ class MakePurchaseHandler(
         handleOnMainThread { result.success(null) }
     }
 
+    private fun refreshUserData(result: MethodChannel.Result) {
+        Apphud.refreshUserData()
+        handleOnMainThread { result.success(null) }
+    }
+
     class ProductParser(private val result: MethodChannel.Result) {
         fun parse(args: Map<String, Any>?, callback: (productIdentifier: String) -> Unit) {
             try {
@@ -283,7 +292,8 @@ enum class MakePurchaseRoutes {
     purchaseProduct,
     permissionGroups,
     paywallsDidLoadCallback,
-    rawPaywalls;
+    rawPaywalls,
+    refreshUserData;
 
     companion object Mapper {
         fun stringValues(): List<String> {

--- a/android/src/main/kotlin/com/apphud/fluttersdk/handlers/PlacementsHandler.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/handlers/PlacementsHandler.kt
@@ -26,7 +26,7 @@ class PlacementsHandler(
                 placement(identifier, result)
             }
 
-            PlacementsRoutes.placementsDidLoadCallback.name -> placementsDidLoadCallback(result)
+            PlacementsRoutes.fetchPlacements.name -> fetchPlacements(result)
 
             PlacementsRoutes.rawPlacements.name -> rawPlacements(result)
         }
@@ -46,10 +46,12 @@ class PlacementsHandler(
         }
     }
 
-    private fun placementsDidLoadCallback(result: MethodChannel.Result) {
-        Apphud.placementsDidLoadCallback { placements ->
-            val map = placements.map { p -> p.toMap() }
-            handleOnMainThread { result.success(map) }
+    private fun fetchPlacements(result: MethodChannel.Result) {
+        Apphud.fetchPlacements { placements, error ->
+            val resultMap = hashMapOf<String, Any?>()
+            resultMap["placements"] = placements.map { placement -> placement.toMap() }
+            resultMap["error"] = error?.toMap()
+            handleOnMainThread { result.success(resultMap) }
         }
     }
 
@@ -75,7 +77,7 @@ class PlacementIdentifierParser(private val result: MethodChannel.Result) {
 enum class PlacementsRoutes {
     placements,
     placement,
-    placementsDidLoadCallback,
+    fetchPlacements,
     rawPlacements;
 
     companion object Mapper {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - apphud (2.4.0):
+  - apphud (2.4.1):
     - ApphudSDK (= 3.2.8)
     - Flutter
   - ApphudSDK (3.2.8)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  apphud: 20ddc6d67d56fe1635718313d4678d4885365eb8
+  apphud: d7143bfc880297b4d35410eddabed857992f6ab6
   ApphudSDK: c1eb87b784a604cff0461112b594cd68a91fc7f6
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
 

--- a/example/lib/src/feature/initialization/initialization_bloc.dart
+++ b/example/lib/src/feature/initialization/initialization_bloc.dart
@@ -28,7 +28,7 @@ class InitializationBloc extends Bloc<InitializationEvent, InitializationState>
     required NavigationBloc navigationBloc,
   })  : _appSecrets = appSecrets,
         _navigationBloc = navigationBloc,
-        super(InitializationState.trying()){
+        super(InitializationState.trying()) {
     _setupListener();
   }
 

--- a/example/lib/src/feature/purchase/purchase_bloc.dart
+++ b/example/lib/src/feature/purchase/purchase_bloc.dart
@@ -449,13 +449,13 @@ class PurchaseBloc extends Bloc<PurchaseEvent, PurchaseState>
     //     ),
     //     onError: (e) => printError('rawPaywalls', e),
     //   );
-    // Apphud.paywallsDidLoadCallback().then(
-    //   (value) => printAsJson(
-    //     'paywallsDidLoadCallback',
-    //     value,
-    //   ),
-    //   onError: (e) => printError('paywallsDidLoadCallback', e),
-    // );
+    Apphud.paywallsDidLoadCallback().then(
+      (value) => printAsJson(
+        'paywallsDidLoadCallback',
+        value,
+      ),
+      onError: (e) => printError('paywallsDidLoadCallback', e),
+    );
     // Apphud.refreshUserData().then(
     //   (value) => printAsJson(
     //     'refreshUserData',

--- a/example/lib/src/feature/purchase/purchase_bloc.dart
+++ b/example/lib/src/feature/purchase/purchase_bloc.dart
@@ -225,22 +225,23 @@ class PurchaseBloc extends Bloc<PurchaseEvent, PurchaseState>
     //   printOnlyMethodName: true,
     // );
     //
-     Apphud.addAttribution(
-       provider: _attributionProvider,
-     ).then(
-       (value) => printAsJson(
-         'Parameters and the result of addAttribution()',
-         <String, dynamic>{
-           'parameters': <String, dynamic>{
-             'data': _attributionData,
-             'provider': _attributionProvider.convertToString,
-           },
-           'result': value,
-         },
-         printOnlyMethodName: true,
-       ),
-       onError: (e) => printError('_setAttribution()', e),
-     );
+    // Apphud.addAttribution(
+    //   provider: _attributionProvider,
+    // ).then(
+    //       (value) =>
+    //       printAsJson(
+    //         'Parameters and the result of addAttribution()',
+    //         <String, dynamic>{
+    //           'parameters': <String, dynamic>{
+    //             'data': _attributionData,
+    //             'provider': _attributionProvider.convertToString,
+    //           },
+    //           'result': value,
+    //         },
+    //         printOnlyMethodName: true,
+    //       ),
+    //   onError: (e) => printError('_setAttribution()', e),
+    // );
     //
     // Apphud.collectSearchAdsAttribution().then(
     //   (value) => printAsJson(
@@ -417,36 +418,50 @@ class PurchaseBloc extends Bloc<PurchaseEvent, PurchaseState>
     //   onError: (e) => printError('paywallsDidLoadCallback', e),
     // );
 
-    final placements = await Apphud.placements();
-    printAsJson('placements', placements);
-
-    if (placements.isNotEmpty) {
-       final placement = await Apphud.placement(placements.first.identifier);
-       printAsJson('placement', placement);
-    }
-
-    Apphud.placementsDidLoadCallback().then(
+    //   final placements = await Apphud.placements();
+    //   printAsJson('placements', placements);
+    //
+    //   if (placements.isNotEmpty) {
+    //      final placement = await Apphud.placement(placements.first.identifier);
+    //      printAsJson('placement', placement);
+    //   }
+    //
+    Apphud.fetchPlacements().then(
       (value) => printAsJson(
-        'placementsDidLoadCallback',
+        'fetchPlacements',
         value,
       ),
-      onError: (e) => printError('placementsDidLoadCallback', e),
+      onError: (e) => printError('fetchPlacements', e),
     );
-
-    Apphud.rawPlacements().then(
-      (value) => printAsJson(
-        'rawPlacements',
-        value,
-      ),
-      onError: (e) => printError('rawPlacements', e),
-    );
-
-    Apphud.rawPaywalls().then(
-      (value) => printAsJson(
-        'rawPaywalls',
-        value,
-      ),
-      onError: (e) => printError('rawPaywalls', e),
-    );
+    //
+    //   Apphud.rawPlacements().then(
+    //     (value) => printAsJson(
+    //       'rawPlacements',
+    //       value,
+    //     ),
+    //     onError: (e) => printError('rawPlacements', e),
+    //   );
+    //
+    //   Apphud.rawPaywalls().then(
+    //     (value) => printAsJson(
+    //       'rawPaywalls',
+    //       value,
+    //     ),
+    //     onError: (e) => printError('rawPaywalls', e),
+    //   );
+    // Apphud.paywallsDidLoadCallback().then(
+    //   (value) => printAsJson(
+    //     'paywallsDidLoadCallback',
+    //     value,
+    //   ),
+    //   onError: (e) => printError('paywallsDidLoadCallback', e),
+    // );
+    // Apphud.refreshUserData().then(
+    //   (value) => printAsJson(
+    //     'refreshUserData',
+    //     'Ok',
+    //   ),
+    //   onError: (e) => printError('refreshUserData', e),
+    // );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.4.3"
+    version: "2.4.4"
   args:
     dependency: transitive
     description:
@@ -314,6 +314,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -326,26 +350,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -374,10 +398,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pool:
     dependency: transitive
     description:
@@ -519,6 +543,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -527,14 +559,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -552,5 +576,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=2.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.4.3"
   args:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftApphudPlugin.swift
+++ b/ios/Classes/SwiftApphudPlugin.swift
@@ -38,6 +38,6 @@ public class SwiftApphudPlugin: NSObject, FlutterPlugin {
     }
     private static func setHeaders() {
         ApphudHttpClient.shared.sdkType = "Flutter"
-        ApphudHttpClient.shared.sdkVersion = "2.4.3"
+        ApphudHttpClient.shared.sdkVersion = "2.4.4"
     }
 }

--- a/ios/Classes/handlers/Handler.swift
+++ b/ios/Classes/handlers/Handler.swift
@@ -143,7 +143,7 @@ enum AppHudMethod {
         case placements
         case placement
         case rawPlacements
-        case placementsDidLoadCallback
+        case fetchPlacements
     }
 }
 

--- a/ios/Classes/handlers/Placements/FetchPlacements.swift
+++ b/ios/Classes/handlers/Placements/FetchPlacements.swift
@@ -8,18 +8,20 @@
 import ApphudSDK
 import StoreKit
 
-final class PlacementsDidLoadCallbackRequest: Request {
+final class FetchPlacementsRequest: Request {
 
-    typealias ArgumentProvider = PlacementsDidLoadCallbackArgumentParser
+    typealias ArgumentProvider = FetchPlacementsArgumentParser
 
     @MainActor func startRequest(arguments: (), result: @escaping FlutterResult) {
         Apphud.placementsDidLoadCallback({ (placements) in
-            result(placements.map({p in p.toMap()}))
+            result([
+                "placements": placements.map({p in p.toMap()})
+            ])
         })
     }
 }
 
-final class PlacementsDidLoadCallbackArgumentParser: Parser {
+final class FetchPlacementsArgumentParser: Parser {
     typealias ArgumentType = ()
 }
 

--- a/ios/Classes/handlers/Placements/PlacementsHandler.swift
+++ b/ios/Classes/handlers/Placements/PlacementsHandler.swift
@@ -16,8 +16,8 @@ class PlacementsHandler: Handler {
             Action<PlacementRequest,PlacementArgumentParser>(args: args, result: result).startFlow()
         case AssociatedEnum.rawPlacements.rawValue:
             Action<RawPlacementsRequest,RawPlacementsArgumentParser>(args: args, result: result).startFlow()
-        case AssociatedEnum.placementsDidLoadCallback.rawValue:
-            Action<PlacementsDidLoadCallbackRequest,PlacementsDidLoadCallbackArgumentParser>(args: args, result: result).startFlow()
+        case AssociatedEnum.fetchPlacements.rawValue:
+            Action<FetchPlacementsRequest,FetchPlacementsArgumentParser>(args: args, result: result).startFlow()
         default:
             break
         }

--- a/ios/Classes/models/ApphudPaywall+toMap.swift
+++ b/ios/Classes/models/ApphudPaywall+toMap.swift
@@ -14,6 +14,8 @@ extension ApphudPaywall {
                 "products" : products.map({ (product:ApphudProduct) in product.toMap() }),
                 "experimentName" : experimentName,
                 "placementIdentifier" : placementIdentifier,
+                "variationName" : variationName,
+                "parentPaywallIdentifier" : parentPaywallIdentifier
         ]
     }
 }

--- a/ios/apphud.podspec
+++ b/ios/apphud.podspec
@@ -5,14 +5,14 @@
 
 Pod::Spec.new do |s|
   s.name             = 'apphud'
-  s.version          = '2.4.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.version          = '2.4.4'
+  s.summary          = 'Apphud SDK flutter plugin.'
   s.description      = <<-DESC
-A new flutter plugin project.
+Apphud SDK flutter plugin.
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://apphud.com'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'Apphud' => 'support@apphud.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'

--- a/lib/models/apphud_models/apphud_error.dart
+++ b/lib/models/apphud_models/apphud_error.dart
@@ -4,12 +4,18 @@ part 'apphud_error.g.dart';
 
 @JsonSerializable(anyMap: true)
 class ApphudError {
+  final bool networkIssue;
   final String? message;
   final int? errorCode;
+  final int? billingResponseCode;
+  final String? billingErrorTitle;
 
   ApphudError({
+    this.networkIssue = false,
     this.message,
     this.errorCode,
+    this.billingResponseCode,
+    this.billingErrorTitle,
   });
 
   factory ApphudError.fromJson(Map<dynamic, dynamic> map) =>
@@ -19,6 +25,6 @@ class ApphudError {
 
   @override
   String toString() {
-    return 'ApphudError{message: $message, errorCode: $errorCode}';
+    return 'ApphudError{networkIssue: $networkIssue, message: $message, errorCode: $errorCode, billingResponseCode: $billingResponseCode, billingErrorTitle: $billingErrorTitle}';
   }
 }

--- a/lib/models/apphud_models/apphud_error.g.dart
+++ b/lib/models/apphud_models/apphud_error.g.dart
@@ -7,12 +7,18 @@ part of 'apphud_error.dart';
 // **************************************************************************
 
 ApphudError _$ApphudErrorFromJson(Map json) => ApphudError(
+      networkIssue: json['networkIssue'] as bool? ?? false,
       message: json['message'] as String?,
       errorCode: json['errorCode'] as int?,
+      billingResponseCode: json['billingResponseCode'] as int?,
+      billingErrorTitle: json['billingErrorTitle'] as String?,
     );
 
 Map<String, dynamic> _$ApphudErrorToJson(ApphudError instance) =>
     <String, dynamic>{
+      'networkIssue': instance.networkIssue,
       'message': instance.message,
       'errorCode': instance.errorCode,
+      'billingResponseCode': instance.billingResponseCode,
+      'billingErrorTitle': instance.billingErrorTitle,
     };

--- a/lib/models/apphud_models/apphud_paywall.dart
+++ b/lib/models/apphud_models/apphud_paywall.dart
@@ -10,6 +10,8 @@ class ApphudPaywall {
   final Map<String, dynamic>? json;
   final List<ApphudProduct>? products;
   final String? placementIdentifier;
+  final String? variationName;
+  final String? parentPaywallIdentifier;
 
   ApphudPaywall({
     required this.identifier,
@@ -17,6 +19,8 @@ class ApphudPaywall {
     this.json,
     this.products,
     this.placementIdentifier,
+    this.variationName,
+    this.parentPaywallIdentifier,
   });
 
   factory ApphudPaywall.fromJson(Map<dynamic, dynamic> map) =>
@@ -26,6 +30,6 @@ class ApphudPaywall {
 
   @override
   String toString() {
-    return 'ApphudPaywall{identifier: $identifier, experimentName: $experimentName, json: $json, products: $products, placementIdentifier: $placementIdentifier}';
+    return 'ApphudPaywall{identifier: $identifier, experimentName: $experimentName, json: $json, products: $products, placementIdentifier: $placementIdentifier, variationName: $variationName, parentPaywallIdentifier: $parentPaywallIdentifier}';
   }
 }

--- a/lib/models/apphud_models/apphud_paywall.g.dart
+++ b/lib/models/apphud_models/apphud_paywall.g.dart
@@ -16,6 +16,8 @@ ApphudPaywall _$ApphudPaywallFromJson(Map json) => ApphudPaywall(
           ?.map((e) => ApphudProduct.fromJson(e as Map))
           .toList(),
       placementIdentifier: json['placementIdentifier'] as String?,
+      variationName: json['variationName'] as String?,
+      parentPaywallIdentifier: json['parentPaywallIdentifier'] as String?,
     );
 
 Map<String, dynamic> _$ApphudPaywallToJson(ApphudPaywall instance) =>
@@ -25,4 +27,6 @@ Map<String, dynamic> _$ApphudPaywallToJson(ApphudPaywall instance) =>
       'json': instance.json,
       'products': instance.products,
       'placementIdentifier': instance.placementIdentifier,
+      'variationName': instance.variationName,
+      'parentPaywallIdentifier': instance.parentPaywallIdentifier,
     };

--- a/lib/models/apphud_models/apphud_placements.dart
+++ b/lib/models/apphud_models/apphud_placements.dart
@@ -1,0 +1,21 @@
+import 'package:apphud/models/apphud_models/apphud_error.dart';
+import 'package:apphud/models/apphud_models/apphud_placement.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'apphud_placements.g.dart';
+
+@JsonSerializable(anyMap: true)
+class ApphudPlacements {
+  final List<ApphudPlacement> placements;
+  final ApphudError? error;
+
+  ApphudPlacements({
+    required this.placements,
+    this.error,
+  });
+
+  factory ApphudPlacements.fromJson(Map<dynamic, dynamic> json) =>
+      _$ApphudPlacementsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ApphudPlacementsToJson(this);
+}

--- a/lib/models/apphud_models/apphud_placements.g.dart
+++ b/lib/models/apphud_models/apphud_placements.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'apphud_placements.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ApphudPlacements _$ApphudPlacementsFromJson(Map json) => ApphudPlacements(
+      placements: (json['placements'] as List<dynamic>)
+          .map((e) => ApphudPlacement.fromJson(e as Map))
+          .toList(),
+      error: json['error'] == null
+          ? null
+          : ApphudError.fromJson(json['error'] as Map),
+    );
+
+Map<String, dynamic> _$ApphudPlacementsToJson(ApphudPlacements instance) =>
+    <String, dynamic>{
+      'placements': instance.placements,
+      'error': instance.error,
+    };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -275,6 +275,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -287,26 +311,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -327,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pedantic:
     dependency: "direct dev"
     description:
@@ -480,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -488,14 +520,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -513,5 +537,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apphud
 description: Official Apphud Flutter SDK is a lightweight open-source library to manage auto-renewable subscriptions and other in-app purchases in your iOS/Android app. No backend required.
-version: 2.4.3
+version: 2.4.4
 homepage: 'https://apphud.com'
 repository: 'https://github.com/apphud/ApphudSDK-Flutter'
 


### PR DESCRIPTION
- [Android] **BREAKING** `Future<List<ApphudPlacement>> placementsDidLoadCallback()` renamed to `Future<ApphudPlacements> fetchPlacements()`
- [Android] `paywallsDidLoadCallback` call result contains optional `ApphudError`
- [Android] `refreshUserData` method was introduced
- [Android] `ApphudError` now contains `networkIssue`, `billingResponseCode` and `billingErrorTitle` attributes 
- [iOS], [Android] `ApphudPaywall` now contains `variationName` and `parentPaywallIdentifier` attributes