### PR TITLE
Release 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.2
 
-- [Android] `trackPurchase` method was introduced
+- [Android] `trackPurchase` method was introduced.
+- [Android] `syncPurchasesInObserverMode` method was deprecated. All purchases on Android are now automatically intercepted and sent to Apphud.  
 
 - Dependencies of Native SDK's were updated to:
     - [Android] 2.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,50 +1,69 @@
+## 2.5.2
+
+- [Android] `trackPurchase` method was introduced
+
+- Dependencies of Native SDK's were updated to:
+    - [Android] 2.7.0
+    - [iOS] 3.4.0
+
 ## 2.5.1
- 
-- [iOS], [Android] Example App was refactored 
+
+- [iOS], [Android] Example App was refactored
 - [Android] `loadFallbackPaywalls` method was introduced
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 2.6.5
-   
+    - [Android] 2.6.5
+
 ## 2.5.0
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 2.6.0
-  - [iOS] 3.3.6
+    - [Android] 2.6.0
+    - [iOS] 3.3.6
 - **BREAKING** `ApphudGroup`'s `products` variable was changed to `List<String> productIds`.
-- 
+-
 
 ## 2.4.5
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 2.4.5
+    - [Android] 2.4.5
 
 ## 2.4.4
 
-- [Android] **BREAKING** `Future<List<ApphudPlacement>> placementsDidLoadCallback()` renamed to `Future<ApphudPlacements> fetchPlacements()`
+- [Android] **BREAKING** `Future<List<ApphudPlacement>> placementsDidLoadCallback()` renamed
+  to `Future<ApphudPlacements> fetchPlacements()`
 - [Android] `paywallsDidLoadCallback` call result contains optional `ApphudError`
 - [Android] `refreshUserData` method was introduced
-- [Android] `ApphudError` now contains `networkIssue`, `billingResponseCode` and `billingErrorTitle` attributes 
-- [iOS], [Android] `ApphudPaywall` now contains `variationName` and `parentPaywallIdentifier` attributes
+- [Android] `ApphudError` now contains `networkIssue`, `billingResponseCode` and `billingErrorTitle`
+  attributes
+- [iOS], [Android] `ApphudPaywall` now contains `variationName` and `parentPaywallIdentifier`
+  attributes
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 2.4.2
-   
+    - [Android] 2.4.2
+
 ## 2.4.3
+
 - [Android] fixed some build issues
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 2.3.9
+    - [Android] 2.3.9
 
 ## 2.4.2
+
 - [iOS] Fixed 'addAttribution' calling issue in some cases
 
 ## 2.4.1
+
 - [Android] Fixed 'paywalls' calling issue in some cases
 
 ## 2.4.0
-- Placements: Offers a strategic method to integrate paywalls throughout your app. This feature allows developers to position paywalls effectively in different app sections, such as onboarding or settings, targeting distinct user audiences. For more comprehensive information, please refer to our Placements guide.
-- [iOS], [Android] **BREAKING** Property 'variationName' were removed from ApphudPaywall, which was confusing developers and lead to incorrect implementations.
+
+- Placements: Offers a strategic method to integrate paywalls throughout your app. This feature
+  allows developers to position paywalls effectively in different app sections, such as onboarding
+  or settings, targeting distinct user audiences. For more comprehensive information, please refer
+  to our Placements guide.
+- [iOS], [Android] **BREAKING** Property 'variationName' were removed from ApphudPaywall, which was
+  confusing developers and lead to incorrect implementations.
 - [iOS] **BREAKING** Method 'didFetchProductsNotification' was removed.
 - [iOS], [Android] **BREAKING** Method 'productsDidFetchCallback' was removed.
 - [iOS] **BREAKING** Method 'refreshStoreKitProducts' was removed.
@@ -57,14 +76,16 @@
 - [iOS] **BREAKING** Method 'fetchRawReceiptInfo' was removed.
 - [iOS] **BREAKING** Method 'isSandbox' was removed.
 - [Android] **BREAKING** Class 'AndroidAccountIdentifiersWrapper' was removed.
-- [Android] **BREAKING** Method 'syncPurchases' was renamed to 'syncPurchasesInObserverMode'. The 'paywallIdentifier' parameter was removed.
+- [Android] **BREAKING** Method 'syncPurchases' was renamed to 'syncPurchasesInObserverMode'. The '
+  paywallIdentifier' parameter was removed.
 - [Android] **BREAKING** Class 'AndroidPurchaseWrapper' was modified.
 - [Android], [iOS] **BREAKING** Class 'ApphudNonRenewingPurchase' was modified.
 - [Android], [iOS] **BREAKING** Class 'ApphudPaywall' was modified.
 - [Android], [iOS] **BREAKING** Class 'ApphudProduct' was modified.
 - [Android], [iOS] **BREAKING** Class 'ApphudSubscriptionWrapper' was modified.
-- [Android], [iOS] Method 'products' always returns 'ApphudProductComposite' list. 
-- [Android], [iOS] **BREAKING**  'ApphudAttributionProvider.appleSearchAds', 'ApphudAttributionProvider.facebook' were modified.
+- [Android], [iOS] Method 'products' always returns 'ApphudProductComposite' list.
+- [Android], [iOS] **BREAKING**  'ApphudAttributionProvider.appleSearchAds', '
+  ApphudAttributionProvider.facebook' were modified.
 - [Android], [iOS] some fixes of the example app
 - [iOS], [Android] 'paywallsDidLoadCallback' method was introduced.
 - [iOS], [Android] 'placements' method was introduced.
@@ -74,125 +95,147 @@
 - [iOS], [Android] 'rawPaywalls' method was introduced.
 - [iOS], [Android] The 'start' and 'startManually' methods now return an ApphudUser object.
 - [iOS], [Android] The 'ApphudListener' 'placementsDidFullyLoad' method was introduced.
-- [iOS], [Android] **BREAKING** The 'ApphudListener' 'userDidLoad' method now returns an ApphudUser object.
+- [iOS], [Android] **BREAKING** The 'ApphudListener' 'userDidLoad' method now returns an ApphudUser
+  object.
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 2.3.7
-  - [iOS] 3.2.8
+    - [Android] 2.3.7
+    - [iOS] 3.2.8
 
 ## 2.3.2
+
 - [Android] Fixed restore purchase issue in some cases
 
 ## 2.3.1
+
 - Fixed purchase result parsing issue in some cases
 
 ## 2.3.0
-- [Android] **BREAKING** SkuDetailsWrapper was replaced by ProductDetailsWrapper because of the migration to Billing v5.
+
+- [Android] **BREAKING** SkuDetailsWrapper was replaced by ProductDetailsWrapper because of the
+  migration to Billing v5.
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 2.0.0
-
+    - [Android] 2.0.0
 
 ## 2.2.15
+
 - [iOS] PUSH notifications handling was added to the example app.
 - [Android] 'optOutOfTracking' and 'collectDeviceIdentifiers' are introduced
 - [Android] **BREAKING** Method `disableAdTracking` is removed.
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.8.0
+    - [Android] 1.8.0
 
 ## 2.2.14
+
 - [Android] Fixes bug with AddAttribution for AppsFlyer provider.
 
 ## 2.2.13
+
 - [Android] Bug fixes
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.7.7
+    - [Android] 1.7.7
 
 ## 2.2.12
+
 - [Android] Bug fixes
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.7.6
+    - [Android] 1.7.6
 
 ## 2.2.11
+
 - [Android] Bug fixes
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.7.5
+    - [Android] 1.7.5
 
 ## 2.2.10
+
 - [Android] Bug fixes
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.7.3
+    - [Android] 1.7.3
 
 ## 2.2.9
+
 - [Android] Bug fixes
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.7.2
+    - [Android] 1.7.2
 
 ## 2.2.8
+
 - [Android] Internal improvements and bug fixes with syncing purchases
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.7.0
+    - [Android] 1.7.0
 
 ## 2.2.7
-- [Android] fixed incorrect ApphudListener behaviour when the ApphudPlugin instance is created twice because of Firebase.
+
+- [Android] fixed incorrect ApphudListener behaviour when the ApphudPlugin instance is created twice
+  because of Firebase.
 - [Android] Internal improvements.
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.6.5
-  
+    - [Android] 1.6.5
+
 ## 2.2.6
+
 - [iOS] Bug fix for Flutter SDK
 - Dependencies of Native SDK's were updated to:
-  - [iOS] 2.8.8
+    - [iOS] 2.8.8
 
 ## 2.2.5
+
 - [iOS], [Android] `ApphudListener`'s method `userDidLoad` is introduced.
-- [iOS], [Android] **BREAKING** Method `paywallsDidLoad` of `ApphudListener` is removed. 
+- [iOS], [Android] **BREAKING** Method `paywallsDidLoad` of `ApphudListener` is removed.
   Please use `ApphudListener`'s methods `userDidLoad` or `paywallsDidFullyLoad` methods,
   depending on whether or not you need `SkuDetails`/`SKProducts` to be already filled in paywalls.
 - [Android] Internal improvements and bug fixing.
-  
+
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.6.4
-  - [iOS] 2.8.5
+    - [Android] 1.6.4
+    - [iOS] 2.8.5
 
 ## 2.2.4
-- [Android] Fixed a bug when ApphudListener’s paywallsDidFullyLoad method wasn’t called in some cases.
+
+- [Android] Fixed a bug when ApphudListener’s paywallsDidFullyLoad method wasn’t called in some
+  cases.
 - [Android] Added new method refreshEntitlements().
 - [iOS] hasActiveSubscription(), hasPremiumAccess() improvements and bug fixes
 - [iOS] Added purchasePromo() logging
 - [iOS] Added checkTransactions logic for force receipt sending if a new transaction was found.
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.6.2
-  - [iOS] 2.8.6
+    - [Android] 1.6.2
+    - [iOS] 2.8.6
 
 ## 2.2.3
+
 - [iOS] Payment swizzle was disabled for observer mode.
 - [iOS] Improved interaction with Apple Search Ads attribution.
 - [iOS] Updated methods description and improve documentation.
 
 - Dependencies of Native SDK's were updated to:
-  - [iOS] 2.8.3
+    - [iOS] 2.8.3
 
 ## 2.2.2
+
 - [iOS], [Android] Method `hasPremiumAccess()` was implemented.
 - [Android] The parameter `paywallIdentifier` was introduced for the method `syncPurchases()`.
 - [iOS] The method `didPurchaseFromPaywall` was implemented.
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.6.0
-  - [iOS] 2.8.1
+    - [Android] 1.6.0
+    - [iOS] 2.8.1
 
 ## 2.2.1
-- [Android] Fixed bug that method hasActiveSubscription was false for paying users at launch before data refreshes. Now value is cached.
+
+- [Android] Fixed bug that method hasActiveSubscription was false for paying users at launch before
+  data refreshes. Now value is cached.
 - [Android] Fixed internal potential crash
 - [iOS] Fixed 403 server error bug, when user could be blocked from sever 403 error code
 - [iOS] Add push token cache
@@ -201,115 +244,138 @@
 
 
 - Dependencies of Native SDK's were updated to:
-  - [Android] 1.5.5
-  - [iOS] 2.5.7
-
+    - [Android] 1.5.5
+    - [iOS] 2.5.7
 
 ## 2.2.0
-- [iOS] The optional parameter 'level' was added to the method enableDebugLogs(). 
-    Possible values are:
+
+- [iOS] The optional parameter 'level' was added to the method enableDebugLogs().
+  Possible values are:
     - 'ApphudDebugLevel.low' - the same as previous amount of debug information.
-    - 'ApphudDebugLevel.high' - enables printing of additional debug messages, for example HTTP requests and responses.
+    - 'ApphudDebugLevel.high' - enables printing of additional debug messages, for example HTTP
+      requests and responses.
 - [iOS], [Android] Automatic fetching of Apphud Flutter SDK version was implemented
 - [iOS] **BREAKING** Method 'disableIDFACollection()' was removed
 - [Android] Method 'grantPromotional()' was implemented
-- [Android], [iOS] Class 'ApphudListener' and method 'setListener({ApphudListener? listener})' were implemented
-- [Android], [iOS] **BREAKING** Method 'getPaywalls()' was removed. Please use ApphudListener instead.
-- [iOS] **BREAKING** Method 'paywallsDidLoadCallback()' was removed. Please use ApphudListener instead.
+- [Android], [iOS] Class 'ApphudListener' and method 'setListener({ApphudListener? listener})' were
+  implemented
+- [Android], [iOS] **BREAKING** Method 'getPaywalls()' was removed. Please use ApphudListener
+  instead.
+- [iOS] **BREAKING** Method 'paywallsDidLoadCallback()' was removed. Please use ApphudListener
+  instead.
 - [Android] Method 'deviceId()' was implemented
-- [Andoid], [iOS] Significantly improved SDK performance and caching. Now SDK will send much less requests to Apphud server.
+- [Andoid], [iOS] Significantly improved SDK performance and caching. Now SDK will send much less
+  requests to Apphud server.
 
- 
+
 - Dependencies of Native SDK's were updated to:
     - [Android] 1.5.3
     - [iOS] 2.5.6
-    
+
 ## 2.1.0
-- [iOS], [Android] Experiments were added. Run Experiments(A/B tests) to test different in-app purchases prices in order to find the best.
-- [iOS] Apple search Ads logic was improved. Submit Apple Attribution Token to Apphud with Apphud.addAttribution().
-- [iOS] Paywalls methods was improved. Paywalls are already exist after SDK initialization. Use paywalls() method.
-- [iOS] paywallsDidLoadCallback() method was added. This callback is called when paywalls are fully loaded with their StoreKit products.
-- [iOS] Promotionals were added. You can grant free promotional subscription to user with new method grantPromotional()
-- [iOS] Fixed important bug when User Properties sometimes may not be saved when submitted simultaneously with initialisation.
+
+- [iOS], [Android] Experiments were added. Run Experiments(A/B tests) to test different in-app
+  purchases prices in order to find the best.
+- [iOS] Apple search Ads logic was improved. Submit Apple Attribution Token to Apphud with
+  Apphud.addAttribution().
+- [iOS] Paywalls methods was improved. Paywalls are already exist after SDK initialization. Use
+  paywalls() method.
+- [iOS] paywallsDidLoadCallback() method was added. This callback is called when paywalls are fully
+  loaded with their StoreKit products.
+- [iOS] Promotionals were added. You can grant free promotional subscription to user with new method
+  grantPromotional()
+- [iOS] Fixed important bug when User Properties sometimes may not be saved when submitted
+  simultaneously with initialisation.
 - [iOS] Fixed a bug when incoming rules did not automatically mark as read.
 - [Android] Paywalls events methods were implemented: paywallShown(), paywallClosed()
 - [Android] Supporting of Google Billing library 4.0 was implemented
 - [iOS], [Android] Properties 'experimentName' and 'variationName' were added to ApphudPaywall.
 - [iOS], [Android] Bug fixing and some internal improvements.
-- [iOS], [Android] Products list was removed from Example app because of deprecation due to Paywalls. 
+- [iOS], [Android] Products list was removed from Example app because of deprecation due to
+  Paywalls.
 
 - **BREAKING** refactor [iOS], [Android]:
     - 'name' property was removed from ApphudPaywall
-     
+
 - Dependencies of Native SDK's were updated to:
     - [Android] 1.3.3
     - [iOS] 2.4.4
 
-## 2.0.6 
+## 2.0.6
+
 - Paywalls features were implemented:
     - method getPaywalls() [iOS], [Android]
     - method permissionGroups() [iOS], [Android]
     - method purchase({ ApphudProduct? product }) [iOS], [Android]
-    - method paywallShown(ApphudPaywall paywall) [iOS]  
+    - method paywallShown(ApphudPaywall paywall) [iOS]
     - method paywallClosed(ApphudPaywall paywall) [iOS]
-    
+
 - Bugs were fixed:
-    - Method restorePurchases() always returns result with error [Android] 
+    - Method restorePurchases() always returns result with error [Android]
 
 - Dependencies of Native SDK's were updated to:
     - [Android] 1.1.3
     - [iOS] 2.1.1
-      
+
 - **BREAKING** refactor [iOS], [Android]:
     - AppHud class was renamed to Apphud
     - ApphudProduct was renamed to ApphudProductComposite and was marked as deprecated
-    - Method purchase(String productId) -> purchase({String? productId}). Parameter productId was marked as deprecated
+    - Method purchase(String productId) -> purchase({String? productId}). Parameter productId was
+      marked as deprecated
 
 - Methods are deprecated:
     - didFetchProductsNotification()
     - refreshStoreKitProducts()
     - product()
     - products()
-     
+
 ## 2.0.5
+
 - [iOS] Add method collectSearchAdsAttribution() to send search ads attribution data to Apphud.
 
 ## 2.0.4
+
 - Update collection dependency
 - Correct readme.md
 
 ## 2.0.3
+
 - Upgrade the example application
 
 ## 2.0.2
+
 - Add method documentation in apphud.dart
 - [Android] Upgrade to use ApphudSDK-Android:1.0.0:
     - Add method restorePurchases
     - Modify purchase method to return ApphudPurchaseResult
 - [iOS] Upgrade to use ApphudSDK 1.2.3
-- Some improvements of example application 
-    
+- Some improvements of example application
+
 ## 2.0.1
+
 - Add methods:
     - presentOfferCodeRedemptionSheet [iOS]
     - validateReceipt [iOS]
     - appStoreReceipt [iOS]
-    - setUserProperty [iOS], [Android] 
-    - incrementUserProperty [iOS], [Android] 
+    - setUserProperty [iOS], [Android]
+    - incrementUserProperty [iOS], [Android]
     - enableDebugLogs [iOS]
     - isSandbox [iOS]
     - disableAdTracking [Android]
-    
+
 ## 2.0.0
+
 - **BREAKING**: refactor: migrate to null safety
     - upgrade Dart SDK constraints to >=2.12.0-0 <3.0.0
 - Some improvements of example application
 
 ## 1.0.1
+
 - [Android] Upgrade to use ApphudSDK-Android:0.8.5
 - [Fixed] [Android] bugs with wrong parameters' names according to Flutter
 - [iOS] Upgrade to use ApphudSDK 1.2
 
 ## 1.0.0
+
 First version Apphud SDK for Flutter
 

--- a/android/.idea/compiler.xml
+++ b/android/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -5,8 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="/usr/local/Cellar/gradle/6.5.1/libexec" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="corretto-1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/.idea/vcs.xml
+++ b/android/.idea/vcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
   </component>
 </project>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "com.apphud:ApphudSDK-Android:2.6.5"
+    implementation "com.apphud:ApphudSDK-Android:2.7.0"
     implementation 'com.android.billingclient:billing:6.1.0'
     implementation 'com.google.code.gson:gson:2.8.8'
 }

--- a/android/src/main/kotlin/com/apphud/fluttersdk/ApphudPlugin.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/ApphudPlugin.kt
@@ -128,7 +128,7 @@ class ApphudPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private fun setHeaders() {
         HeadersInterceptor.X_SDK = "Flutter"
-        HeadersInterceptor.X_SDK_VERSION = "2.5.1"
+        HeadersInterceptor.X_SDK_VERSION = "2.5.2"
     }
 
     override fun onDetachedFromActivityForConfigChanges() {

--- a/example/lib/src/purchase_bloc/purchase_bloc.dart
+++ b/example/lib/src/purchase_bloc/purchase_bloc.dart
@@ -47,6 +47,7 @@ class PurchaseBloc extends Bloc<PurchaseEvent, PurchaseState>
       purchaseProduct: (e) => _handlePurchaseProductEvent(e, emit),
       restorePurchases: (e) => _handleRestorePurchasesEvent(e, emit),
       syncPurchase: (e) => _handleSyncPurchaseEvent(e, emit),
+      trackPurchase: (e) => _handleTrackPurchaseEvent(e, emit),
     );
   }
 
@@ -275,6 +276,16 @@ class PurchaseBloc extends Bloc<PurchaseEvent, PurchaseState>
     Apphud.syncPurchasesInObserverMode().then(
       (value) => printAsJson('syncPurchases()', 'success'),
       onError: (e) => printError('syncPurchases()', e),
+    );
+  }
+
+  Future<void> _handleTrackPurchaseEvent(
+    PurchaseTrackPurchaseEvent event,
+    Emitter<PurchaseState> emit,
+  ) async {
+    Apphud.trackPurchase(productId: event.product.productId).then(
+      (value) => printAsJson('trackPurchase()', 'success'),
+      onError: (e) => printError('trackPurchase()', e),
     );
   }
 

--- a/example/lib/src/purchase_bloc/purchase_event.dart
+++ b/example/lib/src/purchase_bloc/purchase_event.dart
@@ -28,6 +28,9 @@ class PurchaseEvent with _$PurchaseEvent {
   const factory PurchaseEvent.grantPromotional(ApphudProduct product) =
       PurchaseGrantPromotionalEvent;
 
+  const factory PurchaseEvent.trackPurchase(ApphudProduct product) =
+      PurchaseTrackPurchaseEvent;
+
   const factory PurchaseEvent.paywallShown(ApphudPaywall paywall) =
       PurchasePaywallShownEvent;
 

--- a/example/lib/src/purchase_bloc/purchase_event.freezed.dart
+++ b/example/lib/src/purchase_bloc/purchase_event.freezed.dart
@@ -25,6 +25,7 @@ mixin _$PurchaseEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -39,6 +40,7 @@ mixin _$PurchaseEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -53,6 +55,7 @@ mixin _$PurchaseEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -73,6 +76,7 @@ mixin _$PurchaseEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -87,6 +91,7 @@ mixin _$PurchaseEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -101,6 +106,7 @@ mixin _$PurchaseEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -174,6 +180,7 @@ class _$PurchaseStartedEventImpl extends PurchaseStartedEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -191,6 +198,7 @@ class _$PurchaseStartedEventImpl extends PurchaseStartedEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -208,6 +216,7 @@ class _$PurchaseStartedEventImpl extends PurchaseStartedEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -234,6 +243,7 @@ class _$PurchaseStartedEventImpl extends PurchaseStartedEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -251,6 +261,7 @@ class _$PurchaseStartedEventImpl extends PurchaseStartedEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -268,6 +279,7 @@ class _$PurchaseStartedEventImpl extends PurchaseStartedEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -363,6 +375,7 @@ class _$PurchasePaywallsFetchedEventImpl extends PurchasePaywallsFetchedEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -380,6 +393,7 @@ class _$PurchasePaywallsFetchedEventImpl extends PurchasePaywallsFetchedEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -397,6 +411,7 @@ class _$PurchasePaywallsFetchedEventImpl extends PurchasePaywallsFetchedEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -423,6 +438,7 @@ class _$PurchasePaywallsFetchedEventImpl extends PurchasePaywallsFetchedEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -440,6 +456,7 @@ class _$PurchasePaywallsFetchedEventImpl extends PurchasePaywallsFetchedEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -457,6 +474,7 @@ class _$PurchasePaywallsFetchedEventImpl extends PurchasePaywallsFetchedEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -569,6 +587,7 @@ class _$PurchasePlacementsFetchedEventImpl
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -586,6 +605,7 @@ class _$PurchasePlacementsFetchedEventImpl
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -603,6 +623,7 @@ class _$PurchasePlacementsFetchedEventImpl
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -629,6 +650,7 @@ class _$PurchasePlacementsFetchedEventImpl
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -646,6 +668,7 @@ class _$PurchasePlacementsFetchedEventImpl
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -663,6 +686,7 @@ class _$PurchasePlacementsFetchedEventImpl
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -739,6 +763,7 @@ class _$PurchaseRestorePurchasesEventImpl
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -756,6 +781,7 @@ class _$PurchaseRestorePurchasesEventImpl
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -773,6 +799,7 @@ class _$PurchaseRestorePurchasesEventImpl
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -799,6 +826,7 @@ class _$PurchaseRestorePurchasesEventImpl
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -816,6 +844,7 @@ class _$PurchaseRestorePurchasesEventImpl
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -833,6 +862,7 @@ class _$PurchaseRestorePurchasesEventImpl
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -928,6 +958,7 @@ class _$PurchasePurchaseProductEventImpl extends PurchasePurchaseProductEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -945,6 +976,7 @@ class _$PurchasePurchaseProductEventImpl extends PurchasePurchaseProductEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -962,6 +994,7 @@ class _$PurchasePurchaseProductEventImpl extends PurchasePurchaseProductEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -988,6 +1021,7 @@ class _$PurchasePurchaseProductEventImpl extends PurchasePurchaseProductEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -1005,6 +1039,7 @@ class _$PurchasePurchaseProductEventImpl extends PurchasePurchaseProductEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1022,6 +1057,7 @@ class _$PurchasePurchaseProductEventImpl extends PurchasePurchaseProductEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1124,6 +1160,7 @@ class _$PurchaseGrantPromotionalEventImpl
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -1141,6 +1178,7 @@ class _$PurchaseGrantPromotionalEventImpl
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -1158,6 +1196,7 @@ class _$PurchaseGrantPromotionalEventImpl
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -1184,6 +1223,7 @@ class _$PurchaseGrantPromotionalEventImpl
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -1201,6 +1241,7 @@ class _$PurchaseGrantPromotionalEventImpl
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1218,6 +1259,7 @@ class _$PurchaseGrantPromotionalEventImpl
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1240,6 +1282,204 @@ abstract class PurchaseGrantPromotionalEvent extends PurchaseEvent {
   @JsonKey(ignore: true)
   _$$PurchaseGrantPromotionalEventImplCopyWith<
           _$PurchaseGrantPromotionalEventImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PurchaseTrackPurchaseEventImplCopyWith<$Res> {
+  factory _$$PurchaseTrackPurchaseEventImplCopyWith(
+          _$PurchaseTrackPurchaseEventImpl value,
+          $Res Function(_$PurchaseTrackPurchaseEventImpl) then) =
+      __$$PurchaseTrackPurchaseEventImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ApphudProduct product});
+}
+
+/// @nodoc
+class __$$PurchaseTrackPurchaseEventImplCopyWithImpl<$Res>
+    extends _$PurchaseEventCopyWithImpl<$Res, _$PurchaseTrackPurchaseEventImpl>
+    implements _$$PurchaseTrackPurchaseEventImplCopyWith<$Res> {
+  __$$PurchaseTrackPurchaseEventImplCopyWithImpl(
+      _$PurchaseTrackPurchaseEventImpl _value,
+      $Res Function(_$PurchaseTrackPurchaseEventImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? product = null,
+  }) {
+    return _then(_$PurchaseTrackPurchaseEventImpl(
+      null == product
+          ? _value.product
+          : product // ignore: cast_nullable_to_non_nullable
+              as ApphudProduct,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PurchaseTrackPurchaseEventImpl extends PurchaseTrackPurchaseEvent {
+  const _$PurchaseTrackPurchaseEventImpl(this.product) : super._();
+
+  @override
+  final ApphudProduct product;
+
+  @override
+  String toString() {
+    return 'PurchaseEvent.trackPurchase(product: $product)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PurchaseTrackPurchaseEventImpl &&
+            (identical(other.product, product) || other.product == product));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, product);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PurchaseTrackPurchaseEventImplCopyWith<_$PurchaseTrackPurchaseEventImpl>
+      get copyWith => __$$PurchaseTrackPurchaseEventImplCopyWithImpl<
+          _$PurchaseTrackPurchaseEventImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(ApphudPaywalls paywalls) paywallsFetched,
+    required TResult Function(List<ApphudPlacement> placements)
+        placementsFetched,
+    required TResult Function() restorePurchases,
+    required TResult Function(ApphudProduct product) purchaseProduct,
+    required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
+    required TResult Function(ApphudPaywall paywall) paywallShown,
+    required TResult Function(ApphudPaywall paywall) paywallClosed,
+    required TResult Function() syncPurchase,
+    required TResult Function() callAll,
+  }) {
+    return trackPurchase(product);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(ApphudPaywalls paywalls)? paywallsFetched,
+    TResult? Function(List<ApphudPlacement> placements)? placementsFetched,
+    TResult? Function()? restorePurchases,
+    TResult? Function(ApphudProduct product)? purchaseProduct,
+    TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
+    TResult? Function(ApphudPaywall paywall)? paywallShown,
+    TResult? Function(ApphudPaywall paywall)? paywallClosed,
+    TResult? Function()? syncPurchase,
+    TResult? Function()? callAll,
+  }) {
+    return trackPurchase?.call(product);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(ApphudPaywalls paywalls)? paywallsFetched,
+    TResult Function(List<ApphudPlacement> placements)? placementsFetched,
+    TResult Function()? restorePurchases,
+    TResult Function(ApphudProduct product)? purchaseProduct,
+    TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
+    TResult Function(ApphudPaywall paywall)? paywallShown,
+    TResult Function(ApphudPaywall paywall)? paywallClosed,
+    TResult Function()? syncPurchase,
+    TResult Function()? callAll,
+    required TResult orElse(),
+  }) {
+    if (trackPurchase != null) {
+      return trackPurchase(product);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PurchaseStartedEvent value) started,
+    required TResult Function(PurchasePaywallsFetchedEvent value)
+        paywallsFetched,
+    required TResult Function(PurchasePlacementsFetchedEvent value)
+        placementsFetched,
+    required TResult Function(PurchaseRestorePurchasesEvent value)
+        restorePurchases,
+    required TResult Function(PurchasePurchaseProductEvent value)
+        purchaseProduct,
+    required TResult Function(PurchaseGrantPromotionalEvent value)
+        grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
+    required TResult Function(PurchasePaywallShownEvent value) paywallShown,
+    required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
+    required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
+    required TResult Function(PurchaseCallAllEvent value) callAll,
+  }) {
+    return trackPurchase(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PurchaseStartedEvent value)? started,
+    TResult? Function(PurchasePaywallsFetchedEvent value)? paywallsFetched,
+    TResult? Function(PurchasePlacementsFetchedEvent value)? placementsFetched,
+    TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
+    TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
+    TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
+    TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
+    TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
+    TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
+    TResult? Function(PurchaseCallAllEvent value)? callAll,
+  }) {
+    return trackPurchase?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PurchaseStartedEvent value)? started,
+    TResult Function(PurchasePaywallsFetchedEvent value)? paywallsFetched,
+    TResult Function(PurchasePlacementsFetchedEvent value)? placementsFetched,
+    TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
+    TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
+    TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
+    TResult Function(PurchasePaywallShownEvent value)? paywallShown,
+    TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
+    TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
+    TResult Function(PurchaseCallAllEvent value)? callAll,
+    required TResult orElse(),
+  }) {
+    if (trackPurchase != null) {
+      return trackPurchase(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PurchaseTrackPurchaseEvent extends PurchaseEvent {
+  const factory PurchaseTrackPurchaseEvent(final ApphudProduct product) =
+      _$PurchaseTrackPurchaseEventImpl;
+  const PurchaseTrackPurchaseEvent._() : super._();
+
+  ApphudProduct get product;
+  @JsonKey(ignore: true)
+  _$$PurchaseTrackPurchaseEventImplCopyWith<_$PurchaseTrackPurchaseEventImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1317,6 +1557,7 @@ class _$PurchasePaywallShownEventImpl extends PurchasePaywallShownEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -1334,6 +1575,7 @@ class _$PurchasePaywallShownEventImpl extends PurchasePaywallShownEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -1351,6 +1593,7 @@ class _$PurchasePaywallShownEventImpl extends PurchasePaywallShownEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -1377,6 +1620,7 @@ class _$PurchasePaywallShownEventImpl extends PurchasePaywallShownEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -1394,6 +1638,7 @@ class _$PurchasePaywallShownEventImpl extends PurchasePaywallShownEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1411,6 +1656,7 @@ class _$PurchasePaywallShownEventImpl extends PurchasePaywallShownEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1509,6 +1755,7 @@ class _$PurchasePaywallClosedEventImpl extends PurchasePaywallClosedEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -1526,6 +1773,7 @@ class _$PurchasePaywallClosedEventImpl extends PurchasePaywallClosedEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -1543,6 +1791,7 @@ class _$PurchasePaywallClosedEventImpl extends PurchasePaywallClosedEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -1569,6 +1818,7 @@ class _$PurchasePaywallClosedEventImpl extends PurchasePaywallClosedEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -1586,6 +1836,7 @@ class _$PurchasePaywallClosedEventImpl extends PurchasePaywallClosedEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1603,6 +1854,7 @@ class _$PurchasePaywallClosedEventImpl extends PurchasePaywallClosedEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1675,6 +1927,7 @@ class _$PurchaseSyncPurchaseEventImpl extends PurchaseSyncPurchaseEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -1692,6 +1945,7 @@ class _$PurchaseSyncPurchaseEventImpl extends PurchaseSyncPurchaseEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -1709,6 +1963,7 @@ class _$PurchaseSyncPurchaseEventImpl extends PurchaseSyncPurchaseEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -1735,6 +1990,7 @@ class _$PurchaseSyncPurchaseEventImpl extends PurchaseSyncPurchaseEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -1752,6 +2008,7 @@ class _$PurchaseSyncPurchaseEventImpl extends PurchaseSyncPurchaseEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1769,6 +2026,7 @@ class _$PurchaseSyncPurchaseEventImpl extends PurchaseSyncPurchaseEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1833,6 +2091,7 @@ class _$PurchaseCallAllEventImpl extends PurchaseCallAllEvent {
     required TResult Function() restorePurchases,
     required TResult Function(ApphudProduct product) purchaseProduct,
     required TResult Function(ApphudProduct product) grantPromotional,
+    required TResult Function(ApphudProduct product) trackPurchase,
     required TResult Function(ApphudPaywall paywall) paywallShown,
     required TResult Function(ApphudPaywall paywall) paywallClosed,
     required TResult Function() syncPurchase,
@@ -1850,6 +2109,7 @@ class _$PurchaseCallAllEventImpl extends PurchaseCallAllEvent {
     TResult? Function()? restorePurchases,
     TResult? Function(ApphudProduct product)? purchaseProduct,
     TResult? Function(ApphudProduct product)? grantPromotional,
+    TResult? Function(ApphudProduct product)? trackPurchase,
     TResult? Function(ApphudPaywall paywall)? paywallShown,
     TResult? Function(ApphudPaywall paywall)? paywallClosed,
     TResult? Function()? syncPurchase,
@@ -1867,6 +2127,7 @@ class _$PurchaseCallAllEventImpl extends PurchaseCallAllEvent {
     TResult Function()? restorePurchases,
     TResult Function(ApphudProduct product)? purchaseProduct,
     TResult Function(ApphudProduct product)? grantPromotional,
+    TResult Function(ApphudProduct product)? trackPurchase,
     TResult Function(ApphudPaywall paywall)? paywallShown,
     TResult Function(ApphudPaywall paywall)? paywallClosed,
     TResult Function()? syncPurchase,
@@ -1893,6 +2154,7 @@ class _$PurchaseCallAllEventImpl extends PurchaseCallAllEvent {
         purchaseProduct,
     required TResult Function(PurchaseGrantPromotionalEvent value)
         grantPromotional,
+    required TResult Function(PurchaseTrackPurchaseEvent value) trackPurchase,
     required TResult Function(PurchasePaywallShownEvent value) paywallShown,
     required TResult Function(PurchasePaywallClosedEvent value) paywallClosed,
     required TResult Function(PurchaseSyncPurchaseEvent value) syncPurchase,
@@ -1910,6 +2172,7 @@ class _$PurchaseCallAllEventImpl extends PurchaseCallAllEvent {
     TResult? Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult? Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult? Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult? Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult? Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult? Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult? Function(PurchaseSyncPurchaseEvent value)? syncPurchase,
@@ -1927,6 +2190,7 @@ class _$PurchaseCallAllEventImpl extends PurchaseCallAllEvent {
     TResult Function(PurchaseRestorePurchasesEvent value)? restorePurchases,
     TResult Function(PurchasePurchaseProductEvent value)? purchaseProduct,
     TResult Function(PurchaseGrantPromotionalEvent value)? grantPromotional,
+    TResult Function(PurchaseTrackPurchaseEvent value)? trackPurchase,
     TResult Function(PurchasePaywallShownEvent value)? paywallShown,
     TResult Function(PurchasePaywallClosedEvent value)? paywallClosed,
     TResult Function(PurchaseSyncPurchaseEvent value)? syncPurchase,

--- a/example/lib/src/view/widgets/product_list_widget.dart
+++ b/example/lib/src/view/widgets/product_list_widget.dart
@@ -58,6 +58,9 @@ class ProductListWidget extends StatelessWidget {
         onPromote: () => BlocProvider.of<PurchaseBloc>(context).add(
           PurchaseEvent.grantPromotional(product),
         ),
+        onTrackPurchase: () => BlocProvider.of<PurchaseBloc>(context).add(
+          PurchaseEvent.trackPurchase(product),
+        ),
       );
     } else {
       content = Text('No product for this platform');

--- a/example/lib/src/view/widgets/sku_details_widget.dart
+++ b/example/lib/src/view/widgets/sku_details_widget.dart
@@ -7,6 +7,7 @@ class ProductDetailsWidget extends StatelessWidget {
   final ProductDetailsWrapper? productDetails;
   final VoidCallback? onTap;
   final VoidCallback? onPromote;
+  final VoidCallback? onTrackPurchase;
   final bool wrapInCard;
 
   const ProductDetailsWidget({
@@ -14,6 +15,7 @@ class ProductDetailsWidget extends StatelessWidget {
     this.productDetails,
     this.onTap,
     this.onPromote,
+    this.onTrackPurchase,
     bool? wrapInCard,
   })  : wrapInCard = wrapInCard ?? true,
         super(key: key);
@@ -34,9 +36,19 @@ class ProductDetailsWidget extends StatelessWidget {
           subtitle: _buildProductDetailsJson(productDetailsLocal),
           trailing: HeroMode(
             enabled: false,
-            child: FloatingActionButton(
-              onPressed: onPromote,
-              child: Text('P'),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FloatingActionButton(
+                  onPressed: onPromote,
+                  child: Text('P'),
+                ),
+                const SizedBox(width: 10),
+                FloatingActionButton(
+                  onPressed: onTrackPurchase,
+                  child: Text('T'),
+                ),
+              ],
             ),
           ),
         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.5.1"
+    version: "2.5.2"
   args:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftApphudPlugin.swift
+++ b/ios/Classes/SwiftApphudPlugin.swift
@@ -38,6 +38,6 @@ public class SwiftApphudPlugin: NSObject, FlutterPlugin {
     }
     private static func setHeaders() {
         ApphudHttpClient.shared.sdkType = "Flutter"
-        ApphudHttpClient.shared.sdkVersion = "2.5.1"
+        ApphudHttpClient.shared.sdkVersion = "2.5.2"
     }
 }

--- a/ios/apphud.podspec
+++ b/ios/apphud.podspec
@@ -16,7 +16,7 @@ Apphud SDK flutter plugin.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ApphudSDK','3.3.6'
+  s.dependency 'ApphudSDK','3.4.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/apphud.dart
+++ b/lib/apphud.dart
@@ -347,6 +347,36 @@ class Apphud {
     }
   }
 
+  /// Android only. Tracks a purchase made through Google Play. This method should be used only in Observer Mode,
+  /// specifically when utilizing Apphud Paywalls and Placements, and when you need to associate the
+  /// purchase with specific paywall and placement identifiers.
+  ///
+  /// In all other cases, purchases will be automatically intercepted and sent to Apphud.
+  ///
+  /// Note: The `offerIdToken` is mandatory for subscriptions. The `paywallIdentifier` and `placementIdentifier`
+  /// are optional but recommended for A/B test analysis in Observer Mode.
+  ///
+  /// - parameter [productId] The Google Play product ID of the item to purchase.
+  /// - parameter [offerIdToken] The identifier of the subscription's offer token. This parameter is required for subscriptions.
+  /// - parameter [paywallIdentifier] (Optional) The identifier of the paywall.
+  /// - parameter [placementIdentifier] (Optional) The identifier of the placement.
+  static Future<void> trackPurchase({
+    required String productId,
+    String? offerIdToken,
+    String? paywallIdentifier,
+    String? placementIdentifier,
+  }) async {
+    return _channel.invokeMethod(
+      'trackPurchase',
+      {
+        'productId': productId,
+        'offerIdToken': offerIdToken,
+        'paywallIdentifier': paywallIdentifier,
+        'placementIdentifier': placementIdentifier,
+      },
+    );
+  }
+
   /// This method automatically sends in-app purchase receipt to Apphud, so you don't need to call `submitReceipt` method.
   /// - parameter [productId] is required. This is an [productId] that user wants to purchase.
   /// - parameter [discountID] is required. This is a Identifier String object that you would like to apply.

--- a/lib/apphud.dart
+++ b/lib/apphud.dart
@@ -541,11 +541,15 @@ class Apphud {
     return ApphudComposite.fromJson(json);
   }
 
-  /// Android only. This method will send purchases to the Apphud server.
+  /// **Deprecated**.
   ///
-  /// If you use your own purchase logic, you must call this method after every successful purchase or restore.
+  /// Android only. This method is deprecated since version 2.5.2. All purchases on Android are now automatically intercepted and sent to Apphud.
+  /// You no longer need to call this method.
+  ///
+  /// If you want to use paywalls and placements in observer mode, use the new `trackPurchase` method instead.
+  @deprecated
   static Future<void> syncPurchasesInObserverMode() async {
-    await _channel.invokeMethod('syncPurchasesInObserverMode');
+    // This method is now voided and does nothing
   }
 
 // User Properties

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apphud
 description: Official Apphud Flutter SDK is a lightweight open-source library to manage auto-renewable subscriptions and other in-app purchases in your iOS/Android app. No backend required.
-version: 2.5.1
+version: 2.5.2
 homepage: 'https://apphud.com'
 repository: 'https://github.com/apphud/ApphudSDK-Flutter'
 


### PR DESCRIPTION
- [Android] `trackPurchase` method was introduced.
- [Android] `syncPurchasesInObserverMode` method was deprecated. All purchases on Android are now automatically intercepted and sent to Apphud.  

- Dependencies of Native SDK's were updated to:
    - [Android] 2.7.0
    - [iOS] 3.4.0