### PR TITLE
[iOS] Expose networkIssue and errorCode on ApphudError from Flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 3.2.4
 - [iOS] `ApphudError` returned from `purchase`, `purchaseProduct`, `purchasePromo`, `restorePurchases`, `loadFallbackPaywalls` and `showPaywall` now exposes `networkIssue` and `errorCode` instead of only `message`. Previously these fields always came as `false` / `null` on iOS, making it impossible to detect offline/network failures from Flutter.
 
 ## 3.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- [iOS] `ApphudError` returned from `purchase`, `purchaseProduct`, `purchasePromo`, `restorePurchases`, `loadFallbackPaywalls` and `showPaywall` now exposes `networkIssue` and `errorCode` instead of only `message`. Previously these fields always came as `false` / `null` on iOS, making it impossible to detect offline/network failures from Flutter.
+
 ## 3.2.3
 - Dependencies of Native SDK's were updated to:
   - [Android] 3.2.5

--- a/ios/Classes/handlers/HandlePurchases/RestorePurchases.swift
+++ b/ios/Classes/handlers/HandlePurchases/RestorePurchases.swift
@@ -21,8 +21,8 @@ final class RestorePurchasesRequest: @preconcurrency Request {
                 "subscriptions": subscriptionJson != nil ? [subscriptionJson] : [],
                 "nrPurchases": nrPurchaseJson != nil ? [nrPurchaseJson] : [],
             ]
-            if restoreResult.error != nil {
-                dict["error"] = ["message": restoreResult.error?.localizedDescription ?? ""]
+            if let restoreError = restoreResult.error {
+                dict["error"] = restoreError.toApphudErrorMap()
             }
             
             result(dict)

--- a/ios/Classes/handlers/MakePurchase/LoadFallbackPaywalls.swift
+++ b/ios/Classes/handlers/MakePurchase/LoadFallbackPaywalls.swift
@@ -13,9 +13,8 @@ final class LoadFallbackPaywallsRequest: @MainActor Request {
             var resultMap: [String: Any?] = [:]
             
             resultMap["paywalls"] = (paywalls?.map { $0.toMap() }) ?? []
-            if error != nil {
-                resultMap["error"] = ["message": error!.localizedDescription]
-               
+            if let error = error {
+                resultMap["error"] = error.toApphudErrorMap()
             }
             
              result(resultMap)

--- a/ios/Classes/handlers/MakePurchase/ShowPaywall.swift
+++ b/ios/Classes/handlers/MakePurchase/ShowPaywall.swift
@@ -106,7 +106,7 @@ final class ShowPaywallRequest: @preconcurrency Request {
                         result([
                             "success": false,
                             "userClosed": false,
-                            "error": ["message": error.localizedDescription],
+                            "error": error.toApphudErrorMap(),
                         ])
                     }
                 }
@@ -114,7 +114,13 @@ final class ShowPaywallRequest: @preconcurrency Request {
                 result([
                     "success": false,
                     "userClosed": false,
-                    "error": ["message": "Paywall with given identifier not found"],
+                    "error": [
+                        "message": "Paywall with given identifier not found",
+                        "errorCode": nil,
+                        "networkIssue": false,
+                        "billingResponseCode": nil,
+                        "billingErrorTitle": nil,
+                    ],
                 ])
             }
 

--- a/ios/Classes/models/ApphudPurchaseResult+toMap.swift
+++ b/ios/Classes/models/ApphudPurchaseResult+toMap.swift
@@ -28,9 +28,39 @@ extension ApphudPurchaseResult {
     func toMap() -> [String: Any?] {
         return ["subscription" : subscription?.toMap(),
                 "nonRenewingPurchase" : nonRenewingPurchase?.toMap(),
-                "error": error == nil ? nil : ["message": error?.localizedDescription],
+                "error": error?.toApphudErrorMap(),
                 "transaction": transaction?.toMap(),
                 "isRestore": isRestoreResult
+        ]
+    }
+}
+
+extension Error {
+    /// Maps a native error coming from `ApphudPurchaseResult.error`, `Apphud.loadFallbackPaywalls`,
+    /// `Apphud.restorePurchases`, or `Apphud.fetchPaywallScreen` into a dictionary that matches the
+    /// shape of `ApphudError` on the Dart side. Without this mapping `networkIssue` and `errorCode`
+    /// are always `false` / `nil` in Flutter on iOS, which makes offline detection impossible.
+    func toApphudErrorMap() -> [String: Any?] {
+        let nsError = self as NSError
+        let isNetworkIssue: Bool
+        if let apphudError = self as? ApphudError {
+            isNetworkIssue = apphudError.networkIssue()
+        } else {
+            // Same set of codes ApphudError.networkIssue() considers a network issue.
+            let noInternetCodes: Set<Int> = [
+                NSURLErrorNotConnectedToInternet,
+                NSURLErrorCannotConnectToHost,
+                NSURLErrorCannotFindHost,
+                APPHUD_ERROR_NO_INTERNET,
+            ]
+            isNetworkIssue = noInternetCodes.contains(nsError.code)
+        }
+        return [
+            "message": localizedDescription,
+            "errorCode": nsError.code,
+            "networkIssue": isNetworkIssue,
+            "billingResponseCode": nil,
+            "billingErrorTitle": nil,
         ]
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apphud
 description: Official Apphud Flutter SDK is a lightweight open-source library to manage auto-renewable subscriptions and other in-app purchases in your iOS/Android app. No backend required.
-version: 3.2.3
+version: 3.2.4
 homepage: 'https://apphud.com'
 repository: 'https://github.com/apphud/ApphudSDK-Flutter'
 


### PR DESCRIPTION
## Summary

On iOS the Flutter plugin used to forward only `message` from native errors when mapping `ApphudPurchaseResult.error`, `restorePurchases`, `loadFallbackPaywalls` and `showPaywall` results into the Dart layer. As a result, `ApphudError.networkIssue` and `ApphudError.errorCode` on the Flutter side were **always** `false` / `null` on iOS — making it impossible to detect offline / network failures from Flutter (e.g. show a fallback UI when cached paywalls exist but the purchase request fails because there is no internet).

On Android these fields work correctly via `ApphudError.toMap()` in `Extensions.kt` — only iOS needed fixing.

## Changes

- New `Error.toApphudErrorMap()` extension in `ios/Classes/models/ApphudPurchaseResult+toMap.swift`. It:
  - copies `localizedDescription` into `message`
  - copies the underlying `NSError.code` into `errorCode`
  - computes `networkIssue` using the same set of codes the native `ApphudError.networkIssue()` uses: `NSURLErrorNotConnectedToInternet`, `NSURLErrorCannotConnectToHost`, `NSURLErrorCannotFindHost`, `APPHUD_ERROR_NO_INTERNET`. If the error is already an `ApphudError`, delegates to its `.networkIssue()` directly.
- Wire the helper into all 4 error-emitting sites:
  - `ApphudPurchaseResult+toMap.swift` (purchase / purchaseProduct / purchasePromo)
  - `HandlePurchases/RestorePurchases.swift`
  - `MakePurchase/LoadFallbackPaywalls.swift`
  - `MakePurchase/ShowPaywall.swift`
- Format is now symmetric with the Android-side `ApphudError.toMap()` (`billingResponseCode` / `billingErrorTitle` are `nil` on iOS since they are Google Play Billing concepts).

## How this was discovered

Reported by a customer using Flutter SDK 2.7.0: in airplane mode `purchase()` returned `ApphudPurchaseResult.error` with `message = "The Internet connection appears to be offline."` but `networkIssue = false`, blocking them from handling the "cached paywalls but no internet" UX case. Same bug confirmed in current `master` (3.2.3).

## Test plan

- [x] Build the example app on iOS and run `Apphud.purchase(...)` in airplane mode — confirm `result.error?.networkIssue == true` and `result.error?.errorCode == -1009` (or one of `-1004`, `-1003`, `-999`).
- [ ] Run the same flow on Android — confirm `networkIssue` still works (no regression).
- [ ] Trigger a non-network error (e.g. user-cancelled purchase) on iOS — confirm `networkIssue == false` and the `SKError` code is exposed via `errorCode`.