### PR TITLE
[APPHUD-889] Add setScreenPresentationStyle for iOS Rules screens

### DIFF
--- a/android/src/main/kotlin/com/apphud/fluttersdk/handlers/ApphudRuleCallbackHandler.kt
+++ b/android/src/main/kotlin/com/apphud/fluttersdk/handlers/ApphudRuleCallbackHandler.kt
@@ -50,6 +50,12 @@ object ApphudRuleCallbackHandler : ApphudRuleCallback, MethodChannel.MethodCallH
                 result.success(null)
             }
 
+            // iOS-only feature: succeed as a no-op so cross-platform Dart code
+            // can call it unconditionally.
+            "setScreenPresentationStyle" -> {
+                result.success(null)
+            }
+
             else -> result.notImplemented()
         }
     }

--- a/ios/Classes/handlers/ApphudDelegate/ApphudUIDelegateHandler.swift
+++ b/ios/Classes/handlers/ApphudDelegate/ApphudUIDelegateHandler.swift
@@ -23,6 +23,15 @@ public class ApphudUIDelegateHandler: NSObject, FlutterPlugin {
     /// Retains the MainActor UI delegate (type-erased for isolation boundaries).
     private var uiDelegateProxy: NSObject?
 
+    /// Modal presentation style for Rules screens, set via
+    /// `setScreenPresentationStyle`. `nil` means "never set": the delegate
+    /// selector stays hidden and the SDK keeps its default behavior.
+    ///
+    /// Static on purpose: read synchronously from the proxy's nonisolated
+    /// `responds(to:)`, where instance properties of a `@MainActor` type are
+    /// not accessible in the Swift 5.9 language mode.
+    fileprivate static var presentationStyle: UIModalPresentationStyle?
+
     internal init(channel: FlutterMethodChannel) {
         self.channel = channel
     }
@@ -37,6 +46,11 @@ public class ApphudUIDelegateHandler: NSObject, FlutterPlugin {
         case "stopListening":
             stop()
             result(nil)
+        case "setScreenPresentationStyle":
+            let styleString = (call.arguments as? [String: Any])?["style"] as? String
+            setPresentationStyle(styleString) {
+                result(nil)
+            }
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -45,16 +59,52 @@ public class ApphudUIDelegateHandler: NSObject, FlutterPlugin {
     private func start() {
         isListeningStarted = true
         Task { @MainActor in
-            let proxy = ApphudUIDelegateProxy(handler: self)
-            self.uiDelegateProxy = proxy
-            Apphud.setUIDelegate(proxy)
+            self.installProxyIfNeeded()
         }
     }
 
     private func stop() {
         // `Apphud.setUIDelegate` is non-optional; gate events and drop our retain.
         isListeningStarted = false
-        uiDelegateProxy = nil
+        // When a presentation style is set, the proxy stays installed so the
+        // style keeps applying; lifecycle events remain gated by
+        // `isListeningStarted` above.
+        if Self.presentationStyle == nil {
+            uiDelegateProxy = nil
+        }
+    }
+
+    private func setPresentationStyle(_ styleString: String?, completion: @escaping () -> Void) {
+        // Only two supported values; anything else is ignored, state unchanged.
+        let style: UIModalPresentationStyle?
+        switch styleString {
+        case "fullScreen":
+            style = .fullScreen
+        case "pageSheet":
+            style = .pageSheet
+        default:
+            style = nil
+        }
+        guard let style else {
+            NSLog("[Apphud] setScreenPresentationStyle: unsupported style '\(styleString ?? "nil")', ignoring")
+            completion()
+            return
+        }
+        Self.presentationStyle = style
+        // The style must apply even when the rule listener was never started,
+        // so the Dart future completes only after the proxy is installed.
+        Task { @MainActor in
+            self.installProxyIfNeeded()
+            completion()
+        }
+    }
+
+    @MainActor
+    private func installProxyIfNeeded() {
+        guard uiDelegateProxy == nil else { return }
+        let proxy = ApphudUIDelegateProxy(handler: self)
+        uiDelegateProxy = proxy
+        Apphud.setUIDelegate(proxy)
     }
 
     fileprivate func invoke(_ method: String, arguments: [String: Any?]?) {
@@ -70,6 +120,25 @@ final class ApphudUIDelegateProxy: NSObject, ApphudUIDelegate {
     init(handler: ApphudUIDelegateHandler) {
         self.handler = handler
     }
+
+    /// While no presentation style is set, hide the optional delegate selector
+    /// so the native SDK behaves exactly as if the method was never
+    /// implemented (its `apphudScreenPresentationStyle?(...)` optional call
+    /// resolves to `nil` and the controller keeps the system default).
+    public override func responds(to aSelector: Selector!) -> Bool {
+        if aSelector == #selector(ApphudUIDelegate.apphudScreenPresentationStyle(controller:)) {
+            return ApphudUIDelegateHandler.presentationStyle != nil
+        }
+        return super.responds(to: aSelector)
+    }
+
+#if os(iOS)
+    func apphudScreenPresentationStyle(controller: UIViewController) -> UIModalPresentationStyle {
+        // `responds(to:)` above guarantees this is only reached when a style
+        // is set; the fallback keeps the compiler satisfied.
+        return ApphudUIDelegateHandler.presentationStyle ?? .pageSheet
+    }
+#endif
 
     private func currentRuleMap(screenName: String?) -> [String: Any?] {
         if let rule = Apphud.pendingRule() {

--- a/lib/apphud.dart
+++ b/lib/apphud.dart
@@ -17,6 +17,7 @@ import 'package:apphud/models/apphud_models/apphud_subscription.dart';
 import 'package:apphud/models/apphud_models/apphud_user.dart';
 import 'package:apphud/models/apphud_models/apphud_user_property_key.dart';
 import 'package:apphud/models/apphud_models/enums/ios_animation_style.dart';
+import 'package:apphud/models/apphud_models/enums/ios_screen_presentation_style.dart';
 import 'package:flutter/services.dart';
 
 import 'listener/apphud_listener_handler.dart';
@@ -32,6 +33,7 @@ export 'listener/apphud_listener.dart';
 export 'listener/apphud_rule_listener.dart';
 export 'models/apphud_models/apphud_rule.dart';
 export 'models/apphud_models/enums/ios_animation_style.dart';
+export 'models/apphud_models/enums/ios_screen_presentation_style.dart';
 export 'models/apphud_deeplink_attribution.dart';
 
 class Apphud {
@@ -202,6 +204,22 @@ class Apphud {
   }
 
   // === Rules ===
+
+  /// Sets the iOS modal presentation style for Apphud Rules screens
+  /// (including Figma rule paywalls).
+  ///
+  /// Applies to all Rules screens presented after this call. An active rule
+  /// listener is not required. If this method is never called, screens keep
+  /// the SDK's default presentation.
+  ///
+  /// iOS only: on Android the call is a safe no-op.
+  static Future<void> setScreenPresentationStyle(
+    IOSScreenPresentationStyle style,
+  ) =>
+      _ruleListenerChannel.invokeMethod<void>(
+        'setScreenPresentationStyle',
+        {'style': style.stringValue},
+      );
 
   /// Manually polls the backend for unread Apphud Rules and presents a screen
   /// when one is available.

--- a/lib/models/apphud_models/enums/ios_screen_presentation_style.dart
+++ b/lib/models/apphud_models/enums/ios_screen_presentation_style.dart
@@ -1,0 +1,18 @@
+/// Enum representing iOS modal presentation styles for Apphud Rules screens.
+enum IOSScreenPresentationStyle {
+  /// Full screen presentation.
+  fullScreen,
+
+  /// Page sheet presentation (system default since iOS 13).
+  pageSheet;
+
+  /// Converts the enum to a string representation for platform communication.
+  String get stringValue {
+    switch (this) {
+      case IOSScreenPresentationStyle.fullScreen:
+        return 'fullScreen';
+      case IOSScreenPresentationStyle.pageSheet:
+        return 'pageSheet';
+    }
+  }
+}


### PR DESCRIPTION
Adds `Apphud.setScreenPresentationStyle(IOSScreenPresentationStyle.fullScreen | .pageSheet)` to control how Rules screens (including Figma rule paywalls) are presented on iOS.

**Why a separate method:** the native `ApphudUIDelegate.apphudScreenPresentationStyle` returns `UIModalPresentationStyle` synchronously, which cannot be bridged over the async method channel. The chosen style is stored on the native side and returned by the existing UI delegate proxy.

**Behavior details:**
- While the method was never called, the proxy hides the optional selector via a `responds(to:)` override — the SDK default behavior is preserved byte-for-byte (classic screens: system page sheet; Figma screens: full screen).
- Calling the setter installs the UI delegate proxy when the rule listener was never started; the returned `Future` completes only after the proxy is installed, so a set → show sequence is safe.
- `setRuleListener(null)` keeps the proxy alive if a style is set (lifecycle events stay gated by the existing listener flag).
- Android: safe no-op (`success`), the concept is iOS-only.
- Invalid string via raw channel call: ignored with a log, state unchanged.

Verified: `flutter analyze` clean on touched files, example built and smoke-tested on iOS simulator (both styles visually confirmed via a temporary local trigger, not committed) and Android emulator (no-op path). Example app intentionally untouched.
